### PR TITLE
refactor(breadcrumbs): ux review comments

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/breadcrumb-item/gux-breadcrumb-item.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/breadcrumb-item/gux-breadcrumb-item.scss
@@ -129,15 +129,12 @@ $temp-focus-ring-corner-radius: 4px;
       color: var(--gse-ui-link-default-foregroundColor);
       pointer-events: initial;
 
-      &:hover {
-        @include link-breadcrumb-secondary-underline;
-      }
-
       &:visited {
         color: var(--gse-ui-link-visited-foregroundColor);
       }
 
       &:hover {
+        @include link-breadcrumb-secondary-underline;
         color: var(--gse-ui-link-hover-foregroundColor);
       }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/example.html
@@ -4,18 +4,18 @@
 
 <gux-breadcrumbs accent="primary">
   <gux-breadcrumb-item href="#">Breadcrumb Level 1</gux-breadcrumb-item>
-  <gux-breadcrumb-item>Breadcrumb Level 2</gux-breadcrumb-item>
+  <gux-breadcrumb-item href="#">Breadcrumb Level 2</gux-breadcrumb-item>
   <gux-breadcrumb-item href="#">Breadcrumb Level 3</gux-breadcrumb-item>
-  <gux-breadcrumb-item>Breadcrumb Level 4</gux-breadcrumb-item>
+  <gux-breadcrumb-item href="#">Breadcrumb Level 4</gux-breadcrumb-item>
 </gux-breadcrumbs>
 
 <h2>Secondary</h2>
 
 <gux-breadcrumbs accent="secondary">
   <gux-breadcrumb-item href="#">Breadcrumb Level 1</gux-breadcrumb-item>
-  <gux-breadcrumb-item>Breadcrumb Level 2</gux-breadcrumb-item>
+  <gux-breadcrumb-item href="#">Breadcrumb Level 2</gux-breadcrumb-item>
   <gux-breadcrumb-item href="#">Breadcrumb Level 3</gux-breadcrumb-item>
-  <gux-breadcrumb-item>Breadcrumb Level 4</gux-breadcrumb-item>
+  <gux-breadcrumb-item href="#">Breadcrumb Level 4</gux-breadcrumb-item>
 </gux-breadcrumbs>
 
 <h2>Adding and removing</h2>


### PR DESCRIPTION
**Comments**

- In the review comments it was mentioned that the `:visited` styling seems to apply all the time but I think this is a caching issue if I clear my history it seems to work ?
- I added the `href` attribute to all examples just so that all the breadcrumbs are tubbable as was mentioned in the ux review. Maybe it better to to just leave it as is previously was so users can see the differences between using the `href` and not using it ?
- I also updated the order of precedence for the link selectors to match the `LVHA` order. 

https://inindca.atlassian.net/browse/COMUI-2351