### PR TITLE
refactor(accordion): address ux review comments

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-accordion/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-accordion/example.html
@@ -214,3 +214,40 @@
     </div>
   </gux-accordion-section>
 </gux-accordion>
+
+<h2>With content text stylings</h2>
+
+<gux-accordion>
+  <gux-accordion-section disabled>
+    <h2 slot="header">First Section</h2>
+    <div slot="content" class="gux-content-text">
+      <span>I'm a span in a div.</span>
+      <button>I'm the button.</button>
+    </div>
+  </gux-accordion-section>
+  <gux-accordion-section>
+    <h2 slot="header">Second Section</h2>
+    <p slot="content" class="gux-content-text">I'm a p.</p>
+  </gux-accordion-section>
+  <gux-accordion-section>
+    <h2 slot="header">Third Section</h2>
+    <span slot="content" class="gux-content-text">I'm a span.</span>
+  </gux-accordion-section>
+  <gux-accordion-section>
+    <h2 slot="header">
+      Fourth Section has a really really long title to see what it looks like
+      when the title overflows
+    </h2>
+    <span slot="content" class="gux-content-text">I'm a span.</span>
+  </gux-accordion-section>
+</gux-accordion>
+
+<style>
+  .gux-content-text {
+    font-family: var(--gse-ui-accordion-contentItem-defaultText-fontFamily);
+    font-size: var(--gse-ui-accordion-contentItem-defaultText-fontSize);
+    font-weight: var(--gse-ui-accordion-contentItem-defaultText-fontWeight);
+    line-height: var(--gse-ui-accordion-contentItem-defaultText-lineHeight);
+    color: var(--gse-ui-accordion-contentItem-foregroundColor);
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.scss
@@ -55,6 +55,9 @@ section.gux-disabled {
   ::slotted([slot='header']) {
     padding: 0;
     margin: 0;
+    font-family: var(
+      --gse-ui-accordion-header-label-defaultText-fontFamily
+    ) !important;
     font-size: var(
       --gse-ui-accordion-header-label-defaultText-fontFamily
     ) !important;
@@ -64,11 +67,16 @@ section.gux-disabled {
     line-height: var(
       --gse-ui-accordion-header-label-defaultText-lineHeight
     ) !important;
+    color: var(--gse-ui-accordion-header-default-foreground-labelColor);
   }
 
   ::slotted([slot='subheader']) {
+    // TODO COMUI-2370. Missing tokens for subheaders text styling.
     padding: 0;
     margin: var(--gux-spacing-3xs) 0 0;
+    font-family: var(
+      --gse-ui-accordion-contentItem-defaultText-fontFamily
+    ) !important;
     font-size: var(
       --gse-ui-accordion-contentItem-defaultText-fontSize
     ) !important;
@@ -76,6 +84,9 @@ section.gux-disabled {
       --gse-ui-accordion-contentItem-defaultText-fontWeight
     ) !important;
     color: var(--gse-ui-accordion-contentItem-foregroundColor);
+    line-height: var(
+      --gse-ui-accordion-contentItem-defaultText-lineHeight
+    ) !important;
 
     .gux-reverse-headings {
       margin: 0 0 var(--gux-spacing-3xs) 0; // missing token COMUI-1678
@@ -150,5 +161,9 @@ section.gux-disabled {
 
   &.gux-text-content-layout {
     padding: var(--gse-ui-accordion-contentItem-padding);
+  }
+
+  ::slotted([slot='content']) {
+    margin: 0;
   }
 }


### PR DESCRIPTION
**Notes**

- update so h2 stylings are never applied. Missing font-family token has now been applied.
- Added default color token aswell for the header.
- Remove margin around `content` slot should only be applied to the container.
- Added text stylings to the `content` slot. And created ticket to update subheader text stylings once they are created.
- Created token issue as their currently is no tokens for `subheader`.

[COMUI-2358](https://inindca.atlassian.net/browse/COMUI-2358)

Token Issue https://inindca.atlassian.net/browse/COMUI-2370

[COMUI-2358]: https://inindca.atlassian.net/browse/COMUI-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ