### PR TITLE
chore(gux-icon): example page fixes

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
@@ -7,108 +7,151 @@
     <gux-tab tab-id="1-3">Legacy icons</gux-tab>
   </gux-tab-list>
   <gux-tab-panel tab-id="1-1">
-    <h2 id="shadow-dom-header">Shadow DOM</h2>
-    <div id="shadow-dom-host"></div>
-    <p>
-      The `gux-icon` is expected to work even when used in the shadow dom (open)
-    </p>
+    <div>
+      <h2 id="shadow-dom-header">Shadow DOM</h2>
+      <div id="shadow-dom-host"></div>
+      <p>
+        The `gux-icon` is expected to work even when used in the shadow dom
+        (open)
+      </p>
 
-    <h2>Accessibility</h2>
-    <gux-icon icon-name="bus" decorative></gux-icon>
-    <p>
-      Set the <strong>decorative</strong> attrribute if the icon does not convey
-      information about the page and is only for decoration
-    </p>
+      <h2>Accessibility</h2>
+      <gux-icon icon-name="bus" decorative></gux-icon>
+      <p>
+        Set the <strong>decorative</strong> attrribute if the icon does not
+        convey information about the page and is only for decoration
+      </p>
 
-    <gux-icon
-      icon-name="user-add"
-      screenreader-text="add John Smith to contact list"
-    ></gux-icon>
-    <p>
-      Set the <strong>screenreader-text</strong> attribute if the icon conveys
-      information to the user that would not otherwise be available
-    </p>
+      <gux-icon
+        icon-name="user-add"
+        screenreader-text="add John Smith to contact list"
+      ></gux-icon>
+      <p>
+        Set the <strong>screenreader-text</strong> attribute if the icon conveys
+        information to the user that would not otherwise be available
+      </p>
 
-    <gux-icon icon-name="fa/bullseye-regular"></gux-icon>
-    <p>
-      If neither <strong>decorative</strong> or
-      <strong>screenreader-text</strong>
-      are set an error will be logged in the console
-    </p>
+      <gux-icon icon-name="fa/bullseye-regular"></gux-icon>
+      <p>
+        If neither <strong>decorative</strong> or
+        <strong>screenreader-text</strong>
+        are set an error will be logged in the console
+      </p>
 
-    <h2>Styling</h2>
-    <gux-icon id="styled" icon-name="user-add" decorative></gux-icon>
-    <p>
-      You can use the <strong>color</strong>, <strong>height</strong> and
-      <strong>width</strong> css properties to style your icon
-    </p>
+      <h2>Styling</h2>
+      <gux-icon id="styled" icon-name="user-add" decorative></gux-icon>
+      <p>
+        You can use the <strong>color</strong>, <strong>height</strong> and
+        <strong>width</strong> css properties to style your icon
+      </p>
 
-    <h2>Caching</h2>
-    <div>
-      <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      <h2>Sizing</h2>
+      <div class="sizing-container">
+        <div class="sizing-item">
+          <gux-icon
+            class="gux-icon-small"
+            icon-name="user-add"
+            decorative
+          ></gux-icon>
+          <div class="sizing-item-description">
+            <strong>small</strong> (16x16)
+          </div>
+        </div>
+
+        <div class="sizing-item">
+          <gux-icon
+            class="gux-icon-medium"
+            icon-name="user-add"
+            decorative
+          ></gux-icon>
+          <div class="sizing-item-description">
+            <strong>medium</strong> (24x24)
+          </div>
+        </div>
+
+        <div class="sizing-item">
+          <gux-icon
+            class="gux-icon-large"
+            icon-name="user-add"
+            decorative
+          ></gux-icon>
+          <div class="sizing-item-description">
+            <strong>large</strong> (32x32)
+          </div>
+        </div>
+      </div>
+
+      <h2>Caching</h2>
+      <div>
+        <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      </div>
+      <hr />
+      <div>
+        <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      </div>
+      <hr />
+      <div>
+        <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      </div>
+      <hr />
+      <div>
+        <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      </div>
+      <hr />
+      <div>
+        <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
+        <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
+      </div>
+      <hr />
+      <div>
+        <gux-icon icon-name="user" screenreader-text="user-01"></gux-icon>
+        <gux-icon icon-name="user" screenreader-text="user-02"></gux-icon>
+        <gux-icon icon-name="user" screenreader-text="user-03"></gux-icon>
+      </div>
+      <p>Duplicated icons should not require additional network calls</p>
     </div>
-    <hr />
-    <div>
-      <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
-    </div>
-    <hr />
-    <div>
-      <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
-    </div>
-    <hr />
-    <div>
-      <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
-    </div>
-    <hr />
-    <div>
-      <gux-icon icon-name="fa/align-left-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-center-regular" decorative></gux-icon>
-      <gux-icon icon-name="fa/align-right-regular" decorative></gux-icon>
-    </div>
-    <hr />
-    <div>
-      <gux-icon icon-name="user" screenreader-text="user-01"></gux-icon>
-      <gux-icon icon-name="user" screenreader-text="user-02"></gux-icon>
-      <gux-icon icon-name="user" screenreader-text="user-03"></gux-icon>
-    </div>
-    <p>Duplicated icons should not require additional network calls</p>
   </gux-tab-panel>
   <gux-tab-panel tab-id="1-2">
-    <h2>Spark Icons</h2>
-    ${SPARK_ICON_EXAMPLE_LIST}
+    <div>
+      <h2>Spark Icons</h2>
+      ${SPARK_ICON_EXAMPLE_LIST}
 
-    <h2>Font Awesome Icons</h2>
-    <p>
-      <a
-        href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
-        target="_blank"
-        >Request new FontAwesome icons</a
-      >
-    </p>
-    ${FA_ICON_EXAMPLE_LIST}
+      <h2>Font Awesome Icons</h2>
+      <p>
+        <a
+          href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
+          target="_blank"
+          >Request new FontAwesome icons</a
+        >
+      </p>
+      ${FA_ICON_EXAMPLE_LIST}
+    </div>
   </gux-tab-panel>
   <gux-tab-panel tab-id="1-3">
-    <h2>Legacy</h2>
-    <gux-icon icon-name="legacy/cc-delivery" decorative></gux-icon>
-    <p>
-      After a review of icons in this project many of them were removed as they
-      will not be part of the official Spark Design System. You should migrate
-      all usage of these icons where possible and if not possible contact the
-      Spark Design System team to get a suitable icon added to the system. For
-      convenience all legacy icons will be available via a "legacy/" prefix to
-      aid in the transition to officially supported icons.
-    </p>
+    <div>
+      <h2>Legacy</h2>
+      <gux-icon icon-name="legacy/cc-delivery" decorative></gux-icon>
+      <p>
+        After a review of icons in this project many of them were removed as
+        they will not be part of the official Spark Design System. You should
+        migrate all usage of these icons where possible and if not possible
+        contact the Spark Design System team to get a suitable icon added to the
+        system. For convenience all legacy icons will be available via a
+        "legacy/" prefix to aid in the transition to officially supported icons.
+      </p>
 
-    <h2>Legacy Icons (Migrate away from these)</h2>
-    ${LEGACY_ICON_EXAMPLE_LIST}
+      <h2>Legacy Icons (Migrate away from these)</h2>
+      ${LEGACY_ICON_EXAMPLE_LIST}
+    </div>
   </gux-tab-panel>
 </gux-tabs>
 
@@ -118,17 +161,16 @@
   const hostElement = document.getElementById('shadow-dom-host');
   const shadowRoot = hostElement.attachShadow({ mode: 'open' });
   const guxIcon = document.createElement('gux-icon');
-
   guxIcon.setAttribute('icon-name', 'user-add');
   guxIcon.setAttribute('screenreader-text', 'test');
-  guxIcon.setAttribute('style', 'width: 50px; height: 50px;');
+  guxIcon.setAttribute('style', 'width: 32px; height: 32px;');
   shadowRoot.appendChild(guxIcon);
 })()"
 >
   gux-icon {
-    width: 50px;
-    height: 50px;
-    color: #33383d;
+    width: var(--gse-ui-icon-size-lg);
+    height: var(--gse-ui-icon-size-lg);
+    color: var(--gse-core-color-cornflower-700);
   }
 
   #styled {
@@ -148,5 +190,28 @@
     height: 100px;
     margin: 5px;
     text-align: center;
+  }
+
+  .gux-icon-small {
+    width: var(--gse-ui-icon-size-sm);
+    height: var(--gse-ui-icon-size-sm);
+  }
+
+  .gux-icon-medium {
+    width: var(--gse-ui-icon-size-md);
+    height: var(--gse-ui-icon-size-md);
+  }
+
+  .gux-icon-large {
+    width: var(--gse-ui-icon-size-lg);
+    height: var(--gse-ui-icon-size-lg);
+  }
+
+  .sizing-item {
+    margin-bottom: 10px;
+  }
+
+  .sizing-item-description {
+    margin-top: 5px;
   }
 </style>


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-2337

**Made these changes on the example page for gux-icon:**
-Color changed to `color.cornflower.700`
-Rendering 3 different font sizes on the Usage tab: small, medium, and large
-Changed default gux-icon size on other tabs to be 32px