### PR TITLE
ci(github): update reviewer lottery list

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -4,6 +4,7 @@ groups:
     usernames:
       - daragh-king-genesys
       - gavin-everett-genesys
+      - jordanstith15
       - katie-bobbe-genesys
       - MattCheely
-      - conor-darcy
+      - thomas-c-dillon


### PR DESCRIPTION
Thomas and Jordan are active enough now that we should add them to the reviewer list. Conor has been busy with UX work, so it's better if he's out of rotation and tagged in as needed