### PR TITLE
refactor(form-field-checkbox): addition of screen-reader label position

### DIFF
--- a/docs/migration-guides/v4/readme.md
+++ b/docs/migration-guides/v4/readme.md
@@ -201,6 +201,21 @@ Below are the components where the internal margins have been removed for v4:
 6. gux-form-field-text-like
 7. gux-form-field-textarea
 
+#### gux-form-field-checkbox
+
+The `label-position` property has now been added to `gux-form-field-checkbox`. The property can be used to change the position of the label.
+
+- Addition of `label-position` property.
+  - The positions `beside` and `screenreader` are currently available to use. The default `label-position` is `beside`.
+  ```diff
+  + <gux-form-field-checkbox label-position="beside">
+    ...
+    </gux-form-field-checkbox>
+  + <gux-form-field-checkbox label-position="screenreader">
+    ...
+    </gux-form-field-checkbox>
+  ```
+
 ### gux-icon
 
 #### legacy icons

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.scss
@@ -23,6 +23,7 @@
 @use '../gux-form-field-checkbox/gux-form-field-checkbox-icons.scss';
 @use '../../functional-components/gux-form-field-error/gux-form-field-error.scss';
 @use '../../functional-components/gux-form-field-help/gux-form-field-help.scss';
+@use '../../../../../style/mixins';
 
 @include gux-form-field-error.Style;
 @include gux-form-field-help.Style;
@@ -63,13 +64,12 @@
 }
 
 .gux-input-label {
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
   gap: var(--gse-ui-checkbox-gap);
 
-  .gux-label {
-    display: flex;
-    flex-direction: column;
+  .gux-label-screenreader {
+    @include mixins.gux-sr-only;
   }
 }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, JSX, State } from '@stencil/core';
+import { Component, Element, h, Host, JSX, State, Prop } from '@stencil/core';
 
 import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
 import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
@@ -32,6 +32,9 @@ export class GuxFormFieldCheckbox {
   @Element()
   private root: HTMLElement;
 
+  @Prop()
+  labelPosition: 'beside' | 'screenreader' = 'beside';
+
   @State()
   private disabled: boolean;
 
@@ -53,7 +56,7 @@ export class GuxFormFieldCheckbox {
     this.hasError = hasSlot(this.root, 'error');
     this.hasHelp = hasSlot(this.root, 'help');
 
-    trackComponent(this.root);
+    trackComponent(this.root, { variant: this.variant });
   }
 
   disconnectedCallback(): void {
@@ -75,7 +78,7 @@ export class GuxFormFieldCheckbox {
             <div class="gux-input">
               <slot name="input" onSlotchange={() => this.setInput()} />
             </div>
-            <div class="gux-label">
+            <div class={`gux-label-${this.labelPosition}`}>
               <slot name="label" />
               <GuxFormFieldError show={this.hasError}>
                 <slot name="error" />
@@ -88,6 +91,10 @@ export class GuxFormFieldCheckbox {
         </div>
       </Host>
     ) as JSX.Element;
+  }
+
+  private get variant(): string {
+    return this.labelPosition.toLowerCase();
   }
 
   private setInput(): void {

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property        | Attribute        | Description | Type                         | Default    |
+| --------------- | ---------------- | ----------- | ---------------------------- | ---------- |
+| `labelPosition` | `label-position` |             | `"beside" \| "screenreader"` | `'beside'` |
+
+
 ## Slots
 
 | Slot      | Description                     |

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
@@ -8,7 +8,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
@@ -34,7 +34,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
@@ -60,7 +60,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error gux-show">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
@@ -86,7 +86,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
@@ -112,7 +112,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error gux-show">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
@@ -138,7 +138,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (6)
     <div class="gux-input">
       <slot name="input"></slot>
     </div>
-    <div class="gux-label">
+    <div class="gux-label-beside">
       <slot name="label"></slot>
       <div class="gux-form-field-error">
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
@@ -40,7 +40,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
@@ -72,7 +72,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
@@ -107,7 +107,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
@@ -139,7 +139,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
@@ -174,7 +174,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (6)
         <div class="gux-input">
           <slot name="input"></slot>
         </div>
-        <div class="gux-label">
+        <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-all-row-select/gux-all-row-select.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-all-row-select/gux-all-row-select.scss
@@ -1,10 +1,5 @@
 :host {
-  .gux-label-text {
-    position: absolute;
-    top: auto;
-    left: -10000px;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-  }
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-all-row-select/gux-all-row-select.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-all-row-select/gux-all-row-select.tsx
@@ -56,7 +56,7 @@ export class GuxAllRowSelect {
 
   render(): JSX.Element {
     return (
-      <gux-form-field-checkbox>
+      <gux-form-field-checkbox label-position="screenreader">
         <input
           ref={el => (this.inputElement = el)}
           slot="input"
@@ -66,7 +66,7 @@ export class GuxAllRowSelect {
         />
         <label slot="label" htmlFor={this.id}>
           &#8203;
-          <span class="gux-label-text">{this.i18n('selectAllTableRows')}</span>
+          <span>{this.i18n('selectAllTableRows')}</span>
         </label>
       </gux-form-field-checkbox>
     ) as JSX.Element;

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.scss
@@ -1,10 +1,5 @@
 :host {
-  .gux-label-text {
-    position: absolute;
-    top: auto;
-    left: -10000px;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-  }
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.tsx
@@ -51,7 +51,7 @@ export class GuxRowSelect {
 
   render(): JSX.Element {
     return (
-      <gux-form-field-checkbox>
+      <gux-form-field-checkbox label-position="screenreader">
         <input
           ref={el => (this.inputElement = el)}
           slot="input"
@@ -62,7 +62,7 @@ export class GuxRowSelect {
         />
         <label slot="label" htmlFor={this.id}>
           &#8203;
-          <span class="gux-label-text">{this.i18n('selectTableRow')}</span>
+          <span>{this.i18n('selectTableRow')}</span>
         </label>
       </gux-form-field-checkbox>
     ) as JSX.Element;


### PR DESCRIPTION
addition of screen-reader label position. 

This relates to an issue found in the `gux-table` ux review comments where a `form-field-checkbox` is being used with screen-reader text.  https://inindca.atlassian.net/browse/COMUI-2369

For more context I have a ticket here :https://inindca.atlassian.net/browse/COMUI-2384

The `GuxFormFieldLabel` cannot be used here as it has extra positions like `above`