### PR TITLE
fix(gux-listbox-multi): filtering options trims white space

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/example.html
@@ -2,7 +2,7 @@
 <form onchange="notify(event)" oninput="notify(event)">
   <gux-dropdown-multi filter-type="starts-with" placeholder="Select a country">
     <gux-listbox-multi aria-label="Countries">
-      <gux-option-multi value="AFG">Afghanistan</gux-option-multi>
+      <gux-option-multi value="AFG"> Afghanistan </gux-option-multi>
       <gux-option-multi value="ALA">Åland Islands</gux-option-multi>
       <gux-option-multi value="ALB">Albania</gux-option-multi>
       <gux-option-multi value="DZA">Algeria</gux-option-multi>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
@@ -252,6 +252,7 @@ export class GuxListboxMulti {
       );
       if (this.filterType !== 'custom') {
         listboxOption.filtered = !listboxOption.textContent
+          .trim()
           .toLowerCase()
           .startsWith(this.textInput.toLowerCase());
       }


### PR DESCRIPTION
Should we backport this to v3 as well?