### PR TITLE
refactor(table): update focus ring for gux-table-select-menu

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-table-select-menu/gux-table-select-menu.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-table-select-menu/gux-table-select-menu.scss
@@ -1,3 +1,5 @@
+@use '../../../../style/focus';
+
 gux-table-select-menu {
   display: inline-flex;
   font-family: var(--gse-ui-popover-body-text-fontFamily);
@@ -14,12 +16,9 @@ gux-table-select-menu {
     outline: none;
 
     &:focus-visible {
-      gux-icon {
-        border-radius: var(--gse-semantic-focusRing-cornerRadius);
-        outline: var(--gse-semantic-focusRing-width) solid
-          var(--gse-semantic-color-focus);
-        outline-offset: var(--gse-semantic-focusRing-offset);
-      }
+      // TODO: COMUI-2393 need focus ring tokens for table-select-menu dropdown button ?
+      @include focus.gux-focus-ring;
+      border-radius: 4px;
     }
 
     gux-icon {


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-2369

Removed double focus-ring which was occurring on the `gux-table-select-menu` dropdown. Replaced this with the shared focus ring for the time being as we are currently missing a design for this. A token issue has been created.

COMUI-2369