### PR TITLE
fix(gux-form-field-radio): using token for focus style

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.scss
@@ -93,7 +93,7 @@
   outline: var(--gse-ui-radioButton-focus-border-width)
     var(--gse-ui-radioButton-focus-border-style)
     var(--gse-ui-radioButton-focus-border-color);
-  outline-offset: 1px;
+  outline-offset: var(--gse-semantic-focusRing-offset);
 }
 
 ::slotted(input[type='radio']:not(:checked))::before {


### PR DESCRIPTION
Using a token for a focus style. This is a token issue from the work of reskinning the gux-form-field-radio component.