### PR TITLE
fix(blank-state): remove gux-button-slot-beta from shadowDOM

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-blank-state/gux-blank-state.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-blank-state/gux-blank-state.tsx
@@ -1,5 +1,7 @@
-import { Component, Element, JSX, h } from '@stencil/core';
+import { Component, Element, JSX, h, State } from '@stencil/core';
 import { trackComponent } from '@utils/tracking/usage';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { hasSlot } from '@utils/dom/has-slot';
 
 /**
  * @slot primary-message - Required slot for primary-message.
@@ -17,8 +19,28 @@ export class GuxBlankState {
   @Element()
   root: HTMLElement;
 
+  @State()
+  private hasCallToAction: boolean = false;
+
+  @OnMutation({ childList: true, subtree: true })
+  onMutation(): void {
+    this.hasCallToAction = hasSlot(this.root, 'call-to-action');
+  }
+
+  private renderCallToActionSlot(): JSX.Element {
+    if (this.hasCallToAction) {
+      return (
+        <gux-button-slot accent="primary">
+          <slot name="call-to-action"></slot>
+        </gux-button-slot>
+      ) as JSX.Element;
+    }
+  }
+
   componentWillLoad() {
     trackComponent(this.root);
+
+    this.hasCallToAction = hasSlot(this.root, 'call-to-action');
   }
 
   render(): JSX.Element {
@@ -33,9 +55,7 @@ export class GuxBlankState {
         <div class="gux-guidance">
           <slot name="additional-guidance"></slot>
         </div>
-        <gux-button-slot accent="primary">
-          <slot name="call-to-action"></slot>
-        </gux-button-slot>
+        {this.renderCallToActionSlot()}
       </div>
     ) as JSX.Element;
   }


### PR DESCRIPTION
Open to opinions on this change.

I removed the `gux-button-slot-beta` from the `shadowDOM` due to the fact that a user can have a `blank-state` without a call to action button. This will cause errors in the DOM. I think it would be better to just leave it up to the end user to slot a `gux-button` instead if needed ?

I am not sure if there was a reason behind using `gux-button-slot-beta` in shadowDOM.

[COMUI-2241](https://inindca.atlassian.net/browse/COMUI-2241)

[COMUI-2241]: https://inindca.atlassian.net/browse/COMUI-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ