### PR TITLE
fix(tooltip): hiding tooltip when target is scrolled out of view

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -13,6 +13,7 @@ import {
   autoUpdate,
   computePosition,
   flip,
+  hide,
   offset,
   shift,
   Placement,
@@ -111,7 +112,7 @@ export class GuxTooltip {
   }
 
   private updatePosition(): void {
-    const middleware = [offset(16), flip(), shift()];
+    const middleware = [offset(16), flip(), shift(), hide()];
 
     if (this.anchor) {
       middleware.push(arrow({ element: this.arrowElement }));
@@ -124,7 +125,8 @@ export class GuxTooltip {
     }).then(({ x, y, middlewareData, placement }) => {
       Object.assign(this.root.style, {
         left: `${x}px`,
-        top: `${y}px`
+        top: `${y}px`,
+        visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible'
       });
       //data-placement needed on the for e2e tests.
       this.root.setAttribute('data-placement', this.placement);


### PR DESCRIPTION
Closes [COMUI-2114](https://inindca.atlassian.net/browse/COMUI-2114)


Ticket mentions it is in Safari and FF, but I found it in Chrome too.