### PR TITLE
fix(breadcrumb): adding default focus styling to breadcrumb-item

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/breadcrumb-item/gux-breadcrumb-item.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-breadcrumbs/breadcrumb-item/gux-breadcrumb-item.less
@@ -1,5 +1,6 @@
 @import (reference) '../../../../style/color.less';
 @import (reference) '../../../../style/typography.less';
+@import (reference) '../../../../style/focus.less';
 
 .gux-breadcrumb-generation {
   display: flex;
@@ -23,6 +24,11 @@
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    &:focus-visible {
+      border-radius: 4px;
+      .gux-focus-ring();
     }
   }
 


### PR DESCRIPTION
Closes [COMUI-1756](https://inindca.atlassian.net/browse/COMUI-1756)


Breadcrumbs were using the default browser focus-visible styling and not ours. This fixes that

[COMUI-1756]: https://inindca.atlassian.net/browse/COMUI-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ