### PR TITLE
fix(genesys-spark): ensure asset loading is done on the same domain for new regions

### DIFF
--- a/packages/genesys-spark/src/hosts.ts
+++ b/packages/genesys-spark/src/hosts.ts
@@ -7,23 +7,16 @@ declare global {
 // Default domain to load assets from
 const DEFAULT_DOMAIN = 'mypurecloud.com';
 
-// List of Genesys UI domains
-const DOMAIN_LIST = [
-  'apne2.pure.cloud',
-  'aps1.pure.cloud',
-  'cac1.pure.cloud',
-  'euw2.pure.cloud',
+// List of Genesys UI domains that do not follow the ${region}.pure.cloud format
+const NON_STANDARD_DOMAINS = [
   'inindca.com',
   'inintca.com',
   'mypurecloud.com.au',
   'mypurecloud.com',
   'mypurecloud.de',
   'mypurecloud.ie',
-  'mypurecloud.jp',
-  'sae1.pure.cloud',
-  'use2.maximus-pure.cloud',
-  // 'use2.us-gov-pure.cloud', Assets are not currently deployed to FedRAMP and should fallback to the default domain
-  'usw2.pure.cloud'
+  'mypurecloud.jp'
+  // 'use2.us-gov-pure.cloud', Assets are not currently deployed to FedRAMP. It should fall back to the default domain.
 ];
 
 /**
@@ -51,5 +44,14 @@ export function getFontOrigin(): string {
 
 function getRegionDomain() {
   const pageHost = window.location.hostname;
-  return DOMAIN_LIST.find(regionDomain => pageHost.endsWith(regionDomain));
+
+  // We can automatically handle the standard domain format: ${region}.pure.cloud
+  if (pageHost.endsWith('.pure.cloud')) {
+    return pageHost.split('.').slice(-3).join('.');
+  }
+
+  // For older domains, we have to do a lookup
+  return NON_STANDARD_DOMAINS.find(regionDomain =>
+    pageHost.endsWith(regionDomain)
+  );
 }

--- a/packages/genesys-spark/test/hosts.spec.ts
+++ b/packages/genesys-spark/test/hosts.spec.ts
@@ -1,0 +1,69 @@
+import { getAssetsOrigin, getFontOrigin } from "../src/hosts";
+
+const NON_STANDARD_DOMAINS = [
+    'inindca.com',
+    'inintca.com',
+    'mypurecloud.com.au',
+    'mypurecloud.com',
+    'mypurecloud.de',
+    'mypurecloud.ie',
+    'mypurecloud.jp'
+  ];
+
+describe("The hosts module", () => {
+    beforeEach(() => {
+        window.IS_DEV_MODE = false;
+    });
+
+    describe("when determining asset domains", () => {
+        it("Will return the correct domain for pages in a `pure.cloud` region", () => {
+            setLocation("https://uis.region.pure.cloud/page");
+            expect(getAssetsOrigin()).toBe("https://app.region.pure.cloud");
+        })
+
+        it("Will return a default domain for non-genesys hosted pages", () => {
+            setLocation("https://www.example.com/page");
+            expect(getAssetsOrigin()).toBe("https://app.mypurecloud.com");
+        })
+
+        NON_STANDARD_DOMAINS.forEach((domain) => {
+            const withSubDomain = `https://dummySubdomain.${domain}/page`;
+            it(`Will recognize ${withSubDomain} as a Genesys domain`, () => {
+                setLocation(withSubDomain);
+                expect(getAssetsOrigin()).toBe(`https://app.${domain}`);
+            })
+        });
+    })
+
+    describe("when determining font domains", () => {
+        it("Will return the correct domain for pages in a `pure.cloud` region", () => {
+            setLocation("https://uis.region.pure.cloud/page");
+            expect(getFontOrigin()).toBe("https://app.region.pure.cloud");
+        })
+
+        it("Will return a default domain for non-genesys hosted pages", () => {
+            setLocation("https://www.example.com/page");
+            expect(getFontOrigin()).toBe("https://app.mypurecloud.com");
+        })
+
+        NON_STANDARD_DOMAINS.forEach((domain) => {
+            const withSubDomain = `https://dummySubdomain.${domain}/page`;
+            it(`Will recognize ${withSubDomain} as a Genesys domain`, () => {
+                setLocation(withSubDomain);
+                expect(getFontOrigin()).toBe(`https://app.${domain}`);
+            })
+        });
+    })
+})
+
+/**
+ * This is an absolutely disgusting abdication of the type system, but it's a
+ * damn sight simpler than most ways to get dynamic per-test location updates.
+ * See: https://github.com/jestjs/jest/issues/5124
+ */
+function setLocation(location: string) {
+    //@ts-ignore
+    delete window.location
+    //@ts-ignore
+    window.location = new URL(location);
+}


### PR DESCRIPTION
I had hoped to find a way to share this code with what's in `registerCustomElements` in the components package, but I couldn't find a good way to do it.