### PR TITLE
refactor(dropdown,dropdown-multi,listbox): fixing focus in Firefox

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
@@ -142,8 +142,7 @@
     var(--gse-ui-formControl-input-active-border-color);
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
-  &:focus-visible,
-  &:focus-within:has(:focus-visible) {
+  &:focus-visible {
     @include focus.gux-focus-ring;
   }
 
@@ -178,8 +177,7 @@
     var(--gse-ui-formControl-input-default-border-color);
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
-  &:focus-visible,
-  &:focus-within:has(:focus-visible) {
+  &:focus-visible {
     @include focus.gux-focus-ring;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
@@ -146,6 +146,10 @@
     @include focus.gux-focus-ring;
   }
 
+  &:focus-within:has(:focus-visible) {
+    @include focus.gux-focus-ring;
+  }
+
   .gux-filter-input {
     background-color: inherit;
     border: none;
@@ -178,6 +182,10 @@
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
   &:focus-visible {
+    @include focus.gux-focus-ring;
+  }
+
+  &:focus-within:has(:focus-visible) {
     @include focus.gux-focus-ring;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
@@ -145,6 +145,10 @@
     @include gux-input-focus-border;
   }
 
+  &:focus-within:has(:focus-visible) {
+    @include gux-input-focus-border;
+  }
+
   .gux-filter-input {
     background-color: inherit;
     border: none;
@@ -177,6 +181,10 @@
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
   &:focus-visible {
+    @include gux-input-focus-border;
+  }
+
+  &:focus-within:has(:focus-visible) {
     @include gux-input-focus-border;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
@@ -141,8 +141,7 @@
     var(--gse-ui-formControl-input-active-border-color);
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
-  &:focus-visible,
-  &:focus-within:has(:focus-visible) {
+  &:focus-visible {
     @include gux-input-focus-border;
   }
 
@@ -177,8 +176,7 @@
     var(--gse-ui-formControl-input-default-border-color);
   border-radius: var(--gse-ui-formControl-input-borderRadius);
 
-  &:focus-visible,
-  &:focus-within:has(:focus-visible) {
+  &:focus-visible {
     @include gux-input-focus-border;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.scss
@@ -15,7 +15,7 @@
     var(--gse-ui-menu-boxShadow-color);
 }
 
-:host(:focus-visible:not(:host-context(gux-dropdown))) {
+:host(:focus-visible) {
   outline: var(--gse-semantic-focusRing-width) solid
     var(--gse-semantic-color-focus);
   outline-offset: var(--gse-semantic-focusRing-offset);


### PR DESCRIPTION
Closes [COMUI-2465](https://inindca.atlassian.net/browse/COMUI-2465)


Firefox apparently doesn't support :host-context.
Using :has anywhere breaks the whole selector, including ones separated by a comma.

[COMUI-2465]: https://inindca.atlassian.net/browse/COMUI-2465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ