### PR TITLE
fix(gux-form-field): gux-form-field error text vertical alignment fix

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.scss
@@ -5,7 +5,7 @@
     flex-direction: row;
     flex-wrap: nowrap;
     place-content: stretch flex-start;
-    align-items: flex-start;
+    align-items: center;
     padding: var(--gse-ui-formControl-helper-errorPadding);
     font-family: var(--gse-ui-formControl-helper-helperText-fontFamily);
     font-size: var(--gse-ui-formControl-helper-helperText-fontSize);


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-2501

The error text and icon were not vertically aligned in their flex container for all form-field components.

**Before:** 
<img width="239" alt="Screen Shot 2023-11-14 at 8 09 30 AM" src="https://github.com/MyPureCloud/genesys-spark/assets/127438502/b8f9d6e7-fb46-4f34-aab3-1457c295d625">

**After:** 
<img width="235" alt="Screen Shot 2023-11-14 at 8 09 24 AM" src="https://github.com/MyPureCloud/genesys-spark/assets/127438502/f32e2117-71bb-44bb-a4f2-6385749d3526">
