### PR TITLE
fix(genesys-spark): make sure package.json points to generated d.ts

### DIFF
--- a/packages/genesys-spark/package.json
+++ b/packages/genesys-spark/package.json
@@ -6,6 +6,9 @@
   "author": "",
   "type": "module",
   "main": "dist/index.js",
+  "files": [
+    "dist/src/*.d.ts"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c --watch",
@@ -16,6 +19,7 @@
     "test.watch": "jest --watch",
     "version-sync": "npm version --no-git-tag-version --allow-same-version"
   },
+  "types": "dist/src/index.d.ts",
   "dependencies": {
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-typescript": "^11.1.5",


### PR DESCRIPTION
I started to try the new `genesys-spark` package in the navigation app and TS wasn't finding the types. It'd be nicer if I could figure out how to get rollup and ts to put the `.js` and `.d.ts` files in the same spot, but after a trying a bunch of different suggestions with nothing working, I can't be bothered. They can live in different folders.