### PR TITLE
fix(action button): action-button title containing an icon is not vertically centered

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.light.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.light.scss
@@ -1,7 +1,8 @@
 gux-action-button {
   [slot='title'] {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    justify-content: center;
 
     gux-icon {
       width: var(--gse-ui-button-icon-size);


### PR DESCRIPTION
action-button title containing an icon is not vertically centered

[COMUI-2493](https://inindca.atlassian.net/browse/COMUI-2493)