### PR TITLE
feat(gux-modal): add an open property to the modal

### DIFF
--- a/docs/migration-guides/v4/gux-modal-legacy.md
+++ b/docs/migration-guides/v4/gux-modal-legacy.md
@@ -55,7 +55,9 @@ Steps:
 - Use `gux-button-slot` components instead of `gux-button`
 - Remove the `initial-focus` attribute from the `gux-modal` element. Instead, place the `autofocus` attribute on the element that you wish to focus first
 - Remove the `trap-focus` attribute from the `gux-modal` element. The gux-modal uses the [dialog HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) internally, which manages trap focus within the modal
-- Instead of adding and removing the `gux-modal` component from the DOM, use the `showModal` and `close` methods on the `gux-modal` component to hide and show the modal.
+- There are two mechanisms for showing/hiding modals in v4, to support both of the common approaches we see.
+  - You can render the modal, and use the `showModal` and `close` methods on the `gux-modal` element to show and hide it.
+  - Alternatively, if you only want to rener the modal when visible, add the `open` attribute to have it render in an initially open state
 
 ```diff
 -<gux-modal initial-focus="#cancel-button" size="small">

--- a/docs/migration-guides/v4/gux-modal-legacy.md
+++ b/docs/migration-guides/v4/gux-modal-legacy.md
@@ -57,7 +57,7 @@ Steps:
 - Remove the `trap-focus` attribute from the `gux-modal` element. The gux-modal uses the [dialog HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) internally, which manages trap focus within the modal
 - There are two mechanisms for showing/hiding modals in v4, to support both of the common approaches we see.
   - You can render the modal, and use the `showModal` and `close` methods on the `gux-modal` element to show and hide it.
-  - Alternatively, if you only want to rener the modal when visible, add the `open` attribute to have it render in an initially open state
+  - Alternatively, if you only want to render the modal when visible, add the `open` attribute to have it render in an initially open state
 
 ```diff
 -<gux-modal initial-focus="#cancel-button" size="small">

--- a/packages/genesys-spark-components/scripts/generate-component-data.js
+++ b/packages/genesys-spark-components/scripts/generate-component-data.js
@@ -135,6 +135,9 @@ function mdTableToArray(tableMd) {
       },
       text(text) {
         return text;
+      },
+      link(href, title, text) {
+        return `[${text}](${href})`;
       }
     }
   });

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/example.html
@@ -1,6 +1,16 @@
 <h1>gux-modal</h1>
 
 <div>
+  <h2>Showing & Hiding the Modal</h2>
+
+  <p>You can show/hide the `gux-modal` via two mechanisms:</p>
+  <ol>
+    <li>
+      Use the `showModal()` and `close()` methods on a `gux-modal` element
+    </li>
+    <li>Set the `open` property or attribute on `gux-modal`</li>
+  </ol>
+
   <h2>Typical Modal</h2>
 
   <gux-button onclick="document.getElementById('example1').showModal()"

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
@@ -6,7 +6,8 @@ import {
   h,
   JSX,
   Prop,
-  Method
+  Method,
+  Watch
 } from '@stencil/core';
 
 import { randomHTMLId } from '@utils/dom/random-html-id';
@@ -32,25 +33,49 @@ export class GuxModal {
   size: GuxModalSize = 'dynamic';
 
   /**
+   * Indicates/sets whether or not the modal is open. On a native dialog, you should not toggle the
+   * open attribute, due to the unusual behaviors described [here](https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open)
+   * In this component, it is safe as this property acts as a proxy for calls to `showModal` and `close`.
+   */
+  @Prop({ mutable: true })
+  open: boolean = false;
+
+  /**
    * Fired when a user dismisses the modal
    */
   @Event()
   guxdismiss: EventEmitter<void>;
 
+  /**
+   * "Renders" the open state of the modal
+   */
+  @Watch('open')
+  private syncOpenState() {
+    if (this.open) {
+      this.dialogElement.showModal();
+    } else {
+      this.dialogElement.close();
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/require-await
   @Method()
   async showModal(): Promise<void> {
-    this.dialogElement.showModal();
+    this.open = true;
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   @Method()
   async close(): Promise<void> {
-    this.dialogElement.close();
+    this.open = false;
   }
 
   componentWillLoad(): void {
     trackComponent(this.root, { variant: `${this.size}` });
+  }
+
+  componentDidLoad(): void {
+    this.syncOpenState();
   }
 
   private hasModalTitleSlot(): boolean {

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/readme.md
@@ -5,9 +5,10 @@
 
 ## Properties
 
-| Property | Attribute | Description                                              | Type                                          | Default     |
-| -------- | --------- | -------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `size`   | `size`    | Indicates the size of the modal (small, medium or large) | `"dynamic" \| "large" \| "medium" \| "small"` | `'dynamic'` |
+| Property | Attribute | Description                                                                                                                                                                                                                                                                                                                                          | Type                                          | Default     |
+| -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `open`   | `open`    | Indicates/sets whether or not the modal is open. On a native dialog, you should not toggle the open attribute, due to the unusual behaviors described [here](https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open) In this component, it is safe as this property acts as a proxy for calls to `showModal` and `close`. | `boolean`                                     | `false`     |
+| `size`   | `size`    | Indicates the size of the modal (small, medium or large)                                                                                                                                                                                                                                                                                             | `"dynamic" \| "large" \| "medium" \| "small"` | `'dynamic'` |
 
 
 ## Events

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/tests/gux-modal.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/tests/gux-modal.spec.ts
@@ -2,11 +2,71 @@ import { newSpecPage } from '@test/specTestUtils';
 import { GuxButton } from '../../gux-button/gux-button';
 import { GuxModal } from '../gux-modal';
 import { GuxDismissButton } from '../../gux-dismiss-button/gux-dismiss-button';
+import { MockHTMLElement } from '@stencil/core/mock-doc';
+import { SpecPage } from '@stencil/core/internal';
 
 const components = [GuxButton, GuxModal, GuxDismissButton];
 const language = 'en';
 
+//Mocks
+const showModal = jest.fn();
+const close = jest.fn();
+
 describe('gux-modal', () => {
+  beforeAll(() => {
+    // Required until JSDOM supports the dialog element. See:
+    // https://github.com/jsdom/jsdom/issues/3294
+    // https://github.com/jsdom/jsdom/pull/3403
+    Object.assign(MockHTMLElement.prototype, {
+      showModal: showModal,
+      close: close
+    });
+  });
+
+  beforeEach(() => {
+    showModal.mockReset();
+    close.mockReset();
+  });
+
+  it('Should open when rendered with an open attribute', async () => {
+    await modalPage(openModal);
+
+    expect(showModal).toHaveBeenCalled();
+  });
+
+  it('Should not open when rendered without an open attribute', async () => {
+    await modalPage(closedModal);
+
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
+  it('Should close when the open property is set to false', async () => {
+    const page = await modalPage(openModal);
+
+    page.rootInstance.open = false;
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('Should open when the open property is set to true', async () => {
+    const page = await modalPage(closedModal);
+
+    page.rootInstance.open = true;
+    expect(showModal).toHaveBeenCalled();
+  });
+
+  it('Should keep the open property in sync when opened/closed via mehtod', async () => {
+    const page = await modalPage(closedModal);
+    const modal = page.rootInstance;
+
+    expect(modal.open).toBe(false);
+
+    modal.showModal();
+    expect(modal.open).toBe(true);
+
+    modal.close();
+    expect(modal.open).toBe(false);
+  });
+
   describe('#render', () => {
     [
       {
@@ -143,3 +203,17 @@ describe('gux-modal', () => {
     });
   });
 });
+
+const openModal = `
+  <gux-modal size="small" open>
+    <div slot="content">This contains the modal content.</div>
+  </gux-modal>`;
+
+const closedModal = `
+  <gux-modal size="small">
+    <div slot="content">This contains the modal content.</div>
+  </gux-modal>`;
+
+async function modalPage(html: string): Promise<SpecPage> {
+  return await newSpecPage({ components, html, language });
+}

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/tests/gux-modal.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/tests/gux-modal.spec.ts
@@ -54,7 +54,7 @@ describe('gux-modal', () => {
     expect(showModal).toHaveBeenCalled();
   });
 
-  it('Should keep the open property in sync when opened/closed via mehtod', async () => {
+  it('Should keep the open property in sync when opened/closed via method', async () => {
     const page = await modalPage(closedModal);
     const modal = page.rootInstance;
 


### PR DESCRIPTION
This allows the modal to be rendered more easily in the open state, but avoids the pitfalls of the open attribute on the native dialog element by calling `showModal` and `close` behind the scenes.

For folks who were curious from our previous discussion, the dialog HTML spec [outlines why it's preferred to use methods](https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open) over the attribute to show and close `<dialog>` elements.  The tl;dr is it makes the element do surprising things, but isn't an issue here since the property is just a proxy for the internal methods.