### PR TITLE
feat(content-search): shrink text for long navigation info

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-content-search/gux-content-search.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-content-search/gux-content-search.scss
@@ -15,7 +15,7 @@
   box-sizing: border-box;
   flex-basis: 100%;
   flex-shrink: 1;
-  width: 120px;
+  width: 100%;
   overflow: hidden;
   font-family: var(--gse-ui-search-counter-text-fontFamily);
   font-size: var(--gse-ui-search-counter-text-fontSize);


### PR DESCRIPTION
Shrink text for long navigation info

GDS-2247

Does this need to be backported to V3?