### PR TITLE
feat(content-search month-picker): add outline offset on focus

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.scss
@@ -21,6 +21,7 @@
     outline: var(--gse-ui-formControl-input-focus-border-width)
       var(--gse-ui-formControl-input-focus-border-style)
       var(--gse-ui-formControl-input-focus-border-color);
+    outline-offset: var(--gse-semantic-focusRing-offset);
   }
 
   .gux-display {

--- a/packages/genesys-spark-components/src/components/stable/gux-content-search/gux-content-search.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-content-search/gux-content-search.scss
@@ -77,6 +77,7 @@
     outline: var(--gse-ui-formControl-input-focus-border-width)
       var(--gse-ui-formControl-input-focus-border-style)
       var(--gse-ui-formControl-input-focus-border-color);
+    outline-offset: var(--gse-semantic-focusRing-offset);
   }
 
   &:not(:disabled):not(.gux-disabled):hover {


### PR DESCRIPTION
Add outline offset on focus

GDS-2250

Does this need to be backported to v3?