### PR TITLE
feat(migration guide links): point migration guide links to the right place

### DIFF
--- a/packages/genesys-spark-components/src/components/legacy/gux-action-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-action-toast-legacy/example.html
@@ -13,7 +13,7 @@
   <a href="/#gux-toast" target="_blank">gux-toast</a>
   <span>component instead. See the </span>
   <a
-    href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+    href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
     target="_blank"
     >migration guide</a
   >

--- a/packages/genesys-spark-components/src/components/legacy/gux-advanced-dropdown-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-advanced-dropdown-legacy/example.html
@@ -17,7 +17,7 @@
   <a href="/#gux-dropdown" target="_blank">gux-dropdown</a>
   <span>components instead. See the </span>
   <a
-    href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+    href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
     target="_blank"
     >migration guide</a
   >

--- a/packages/genesys-spark-components/src/components/legacy/gux-disclosure-button-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-disclosure-button-legacy/example.html
@@ -11,7 +11,7 @@
     future major releases. See the
   </span>
   <a
-    href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+    href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
     target="_blank"
     >migration guide</a
   >

--- a/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/example.html
@@ -13,7 +13,7 @@
   <a href="/#gux-modal" target="_blank">gux-modal</a>
   <span> component instead. See the </span>
   <a
-    href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+    href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
     target="_blank"
     >migration guide</a
   >

--- a/packages/genesys-spark-components/src/components/legacy/gux-notification-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-notification-toast-legacy/example.html
@@ -14,7 +14,7 @@
     <a href="/#gux-toast" target="_blank">gux-toast</a>
     <span>component instead. See the </span>
     <a
-      href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+      href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
       target="_blank"
       >migration guide</a
     >

--- a/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/example.html
@@ -12,7 +12,7 @@
     <a href="/#gux-pagination" target="_blank">gux-pagination</a>
     <span>component instead. See the </span>
     <a
-      href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+      href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
       target="_blank"
       >migration guide</a
     >

--- a/packages/genesys-spark-components/src/components/legacy/gux-simple-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-simple-toast-legacy/example.html
@@ -14,7 +14,7 @@
     <a href="/#gux-toast" target="_blank">gux-toast</a>
     <span>component instead. See the </span>
     <a
-      href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+      href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
       target="_blank"
       >migration guide</a
     >

--- a/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/example.html
@@ -11,7 +11,7 @@
     future major releases. See the
   </span>
   <a
-    href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4"
+    href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md"
     target="_blank"
     >migration guide</a
   >

--- a/web-apps/genesys-spark-examples/src/component-listing/app.js
+++ b/web-apps/genesys-spark-examples/src/component-listing/app.js
@@ -40,7 +40,7 @@ export async function bootstrap() {
                   .join('')}
                   <div class="sticky-footer">
                   <h2>Resources</h2>
-                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-spark/tree/main/packages/genesys-spark-components/documentation/migrations/v4" target="_blank">V3 -> V4 Migration Guide</a>
+                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-spark/blob/main/docs/migration-guides/v4/readme.md" target="_blank">V3 -> V4 Migration Guide</a>
                     <a class="resources-link" href="https://spark.genesys.com" target="_blank">Spark 4.0 UX Documentation</a>
                     <a class="resources-link" href="https://github.com/MyPureCloud/genesys-spark/blob/main/README.md#genesys-web-components" target="_blank">Genesys Spark Components README</a>
                   </div>


### PR DESCRIPTION
Point migration guide links to the right place

Looks to come from the Resources section in bottom-left corner and all of the legacy components