### PR TITLE
docs(genesys-spark-components readme): update links to correct relative paths

### DIFF
--- a/packages/genesys-spark-components/README.md
+++ b/packages/genesys-spark-components/README.md
@@ -15,7 +15,7 @@ At any given time there are three types of components present in the library:
 - **beta**: New components where the API design is still being explored. Breaking changes _may_ happen without a major version change.
 - **legacy**: Old components that have been replaced by a new component, or a newer version of the component with an incompatible API. These will be removed in the next major release.
 
-For more details on the component evolution process see the full [documentation on the topic](./packages/genesys-spark-components/documentation/COMPONENT_EVOLUTION.md)
+For more details on the component evolution process see the full [documentation on the topic](../../packages/genesys-spark-components/documentation/COMPONENT_EVOLUTION.md)
 
 ## Demo/Documentation
 
@@ -75,10 +75,6 @@ You will need to set a lang attribute on the a component or one of its ancestor 
 Normally, you should set it on the page somewhere at a high level, e.g. `<html lang="en">` or `<body lang="en">`
 and the components will localize based on that. If no language is set, the components default to English.
 
-### Framework Integration Notes
-
-- [React](./packages/genesys-spark-components/documentation/REACT_INTEGRATION.md)
-
 ## Development and Contribution
 
 The common component library has a small set of developers, who also work on other projects, so
@@ -86,7 +82,11 @@ contribution from users is welcome. If you need a new feature, the best way to g
 with the team to implement it yourself. Please reach out to discuss your work _before_ opening a PR.
 An early conversation is the best way to avoid duplicated effort.
 
-Also, be sure to read the [Contributing Guidelines](./packages/genesys-spark-components/documentation/CONTRIBUTING.md) before starting development work.
+Also, be sure to read the [Contributing Guidelines](../../docs/CONTRIBUTING.md) before starting development work.
+
+#### Migrating to V4
+
+Visit the [V4 migration guide](../../docs/migration-guides/v4/readme.md) for details on the new v4 release and migration details.
 
 ### Serving component and docs
 

--- a/packages/genesys-spark-components/README.md
+++ b/packages/genesys-spark-components/README.md
@@ -75,6 +75,10 @@ You will need to set a lang attribute on the a component or one of its ancestor 
 Normally, you should set it on the page somewhere at a high level, e.g. `<html lang="en">` or `<body lang="en">`
 and the components will localize based on that. If no language is set, the components default to English.
 
+### Framework Integration Notes
+
+- [React](../../packages/genesys-spark-components-react/README.md)
+
 ## Development and Contribution
 
 The common component library has a small set of developers, who also work on other projects, so

--- a/packages/genesys-spark-components/documentation/COMPONENT_EVOLUTION.md
+++ b/packages/genesys-spark-components/documentation/COMPONENT_EVOLUTION.md
@@ -4,7 +4,7 @@ This document describes a mechanism for handling breaking changes to components 
 changes) in a way that supports gradual adoption by development teams. We also want to limit how
 often teams have to deal with breaking changes to a fairly regular and infrequent cadence.
 
-## Beta, Supported, Legacy Cycle
+## Beta, Stable, Legacy Cycle
 
 The mechanism for handling these transitions will be for breaking changes in components to go through
 a series of states:
@@ -12,7 +12,7 @@ a series of states:
 - Beta: Beta components are available in the library for early adopters, but subject to breaking
   change without a major version bump, most likely based on feedback from the teams using it.
 
-- Supported: This is the normal component version, the default approach teams should use. No breaking
+- Stable: This is the normal component version, the default approach teams should use. No breaking
   changes outside of a major package version bump. Most components should be in this state most of the
   time.
 
@@ -27,28 +27,28 @@ the component element names for the respective states.
 
 On a major release all component state changes will be documented and presented in an easy to follow migration guide.
 
-### beta → supported
+### beta → stable
 
 If the application is using the latest beta version of the component there will be no need for code
 changes other than removing the `-beta` suffix. If the beta version is out of date there may be a
 need for some development work as the components api may have changed. A component will not move to
-the supported state unless it is well documented so this migration should be straight-forward.
+the stable state unless it is well documented so this migration should be straight-forward.
 
-### supported → legacy
+### stable → legacy
 
 There will be no need for code changes other than adding the `-legacy` suffix. At this stage the
-development team should start planning to move to the supported version before the next major release.
+development team should start planning to move to the stable version before the next major release.
 
-### legacy → supported
+### legacy → stable
 
 When a component version is deprecating a migration guide will be created to help development teams
-move to the newly supported component.
+move to the newly stable component.
 
 ## Rotation Schedule
 
-Components will rotate through the beta/supported/legacy cycle on roughly a quarterly basis.
+Components will rotate through the beta/stable/legacy cycle on roughly a quarterly basis.
 Once a quarter, any beta components implementations that are sufficiently stable will become
-supported components. The previously supported version of that component will become legacy,
+stable components. The previously stable version of that component will become legacy,
 and any previously legacy components will be removed from the library entirely.
 
 For a team that does not want to migrate right away to the new APIs, staying on the legacy


### PR DESCRIPTION
Some links in the genesys-spark-components readme were broken, I've updated these to their new targets where possible. 

I couldn't find a react integration guide so I took that out. Also, added a link to the migration guide just since it's topical. 

Just to be clear, since they're not linked to GitHub this might still not work on npm (it doesn't currently either). I can replace the relative links with links there instead, just let me know what's prefered.

Update links to correct relative paths