### PR TITLE
[WIP] feat(option): add subtext to option and list option groups

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
@@ -7,12 +7,14 @@ import {
   Host,
   JSX,
   Prop,
+  State,
   Watch
 } from '@stencil/core';
 
 import { randomHTMLId } from '@utils/dom/random-html-id';
 import { buildI18nForComponent, GetI18nValue } from '../../../../i18n';
 import translationResources from './i18n/en.json';
+import { hasSlot } from '@utils/dom/has-slot';
 
 /**
  * @slot - text
@@ -57,6 +59,9 @@ export class GuxOptionMulti {
   @Event()
   internalselectcustomoption: EventEmitter<string>;
 
+  @State()
+  private hasSubtext: boolean = false;
+
   @Watch('selected')
   emitRemoveCustomOption() {
     if (!this.selected && this.custom) {
@@ -78,6 +83,7 @@ export class GuxOptionMulti {
     if (this.custom) {
       this.internalselectcustomoption.emit(this.value);
     }
+    this.hasSubtext = hasSlot(this.root, 'subtext');
   }
 
   // SVGs must be in DOM for tokenization to work
@@ -133,7 +139,9 @@ export class GuxOptionMulti {
           >
             <slot />
           </gux-truncate>
-          <p>{this.subtext}</p>
+          <span>
+            <slot name="subtext"></slot>
+          </span>
         </div>
       ) as JSX.Element;
     } else {
@@ -157,7 +165,7 @@ export class GuxOptionMulti {
           'gux-disabled': this.disabled,
           'gux-filtered': this.filtered,
           'gux-selected': this.selected,
-          'gux-show-subtext': !!this.subtext
+          'gux-show-subtext': this.hasSubtext
         }}
         aria-selected={this.selected.toString()}
         aria-disabled={this.disabled.toString()}

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
@@ -36,9 +36,6 @@ export class GuxOptionMulti {
   value: string;
 
   @Prop()
-  subtext: string;
-
-  @Prop()
   active: boolean = false;
 
   @Prop({ mutable: true })
@@ -130,7 +127,7 @@ export class GuxOptionMulti {
   private renderText(): JSX.Element {
     // The gux-slot-container attribute is used in gux-listbox-multi and gux-dropdown-multi as a selector to get the slotted gux-option-multi text.
     // This attribute is required because we need to get the slotted text and exclude the screen reader text.
-    if (this.subtext) {
+    if (this.hasSubtext) {
       return (
         <div class="gux-option-text">
           <gux-truncate

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/gux-option-multi.tsx
@@ -34,6 +34,9 @@ export class GuxOptionMulti {
   value: string;
 
   @Prop()
+  subtext: string;
+
+  @Prop()
   active: boolean = false;
 
   @Prop({ mutable: true })
@@ -118,6 +121,33 @@ export class GuxOptionMulti {
     }
   }
 
+  private renderText(): JSX.Element {
+    // The gux-slot-container attribute is used in gux-listbox-multi and gux-dropdown-multi as a selector to get the slotted gux-option-multi text.
+    // This attribute is required because we need to get the slotted text and exclude the screen reader text.
+    if (this.subtext) {
+      return (
+        <div class="gux-option-text">
+          <gux-truncate
+            gux-slot-container
+            ref={el => (this.truncateElement = el)}
+          >
+            <slot />
+          </gux-truncate>
+          <p>{this.subtext}</p>
+        </div>
+      ) as JSX.Element;
+    } else {
+      return (
+        <gux-truncate
+          gux-slot-container
+          ref={el => (this.truncateElement = el)}
+        >
+          <slot />
+        </gux-truncate>
+      ) as JSX.Element;
+    }
+  }
+
   render(): JSX.Element {
     return (
       <Host
@@ -126,21 +156,14 @@ export class GuxOptionMulti {
           'gux-active': this.active,
           'gux-disabled': this.disabled,
           'gux-filtered': this.filtered,
-          'gux-selected': this.selected
+          'gux-selected': this.selected,
+          'gux-show-subtext': !!this.subtext
         }}
         aria-selected={this.selected.toString()}
         aria-disabled={this.disabled.toString()}
       >
         {this.renderSVGCheckbox()}
-        {/* The gux-slot-container attribute is used in gux-listbox-multi and gux-dropdown-multi as a selector to get the slotted gux-option-multi text.
-        This attribute is required because we need to get the slotted text and exclude the screen reader text. */}
-        <gux-truncate
-          gux-slot-container
-          ref={el => (this.truncateElement = el)}
-        >
-          <slot />
-        </gux-truncate>
-
+        {this.renderText()}
         {this.renderCustomOptionInstructions()}
       </Host>
     ) as JSX.Element;

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-option-multi/readme.md
@@ -12,6 +12,7 @@
 | `disabled` | `disabled` |             | `boolean` | `false`     |
 | `filtered` | `filtered` |             | `boolean` | `false`     |
 | `selected` | `selected` |             | `boolean` | `false`     |
+| `subtext`  | `subtext`  |             | `string`  | `undefined` |
 | `value`    | `value`    |             | `string`  | `undefined` |
 
 

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
@@ -1,5 +1,11 @@
 <h1>gux-listbox</h1>
 <form onchange="notify(event)" oninput="notify(event)">
+  <h3>Subtext Test</h3>
+  <gux-listbox value="b" aria-label="Animals">
+    <gux-option value="a" subtext="Subtext">Ant </gux-option>
+    <gux-option value="b" subtext="Subtext">Bat</gux-option>
+  </gux-listbox>
+
   <h3>Typical</h3>
   <gux-listbox value="b" aria-label="Animals">
     <gux-option value="a" disabled>Ant</gux-option>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
@@ -2,8 +2,8 @@
 <form onchange="notify(event)" oninput="notify(event)">
   <h3>Subtext Test</h3>
   <gux-listbox value="b" aria-label="Animals">
-    <gux-option value="a" subtext="Subtext">Ant </gux-option>
-    <gux-option value="b" subtext="Subtext">Bat</gux-option>
+    <gux-option value="a">Ant <span slot="subtext">Subtext</span></gux-option>
+    <gux-option value="b">Bat <span slot="subtext">Subtext</span></gux-option>
   </gux-listbox>
 
   <h3>Typical</h3>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
@@ -1,9 +1,11 @@
 <h1>gux-listbox</h1>
 <form onchange="notify(event)" oninput="notify(event)">
-  <h3>Subtext Test</h3>
+  <h3>Group with subtext - WIP</h3>
   <gux-listbox value="b" aria-label="Animals">
-    <gux-option value="a">Ant <span slot="subtext">Subtext</span></gux-option>
-    <gux-option value="b">Bat <span slot="subtext">Subtext</span></gux-option>
+    <gux-option-group title="Group label">
+      <gux-option value="a">Ant <span slot="subtext">Subtext</span></gux-option>
+      <gux-option value="b">Bat <span slot="subtext">Subtext</span></gux-option>
+    </gux-option-group>
   </gux-listbox>
 
   <h3>Typical</h3>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/example.html
@@ -3,8 +3,18 @@
   <h3>Group with subtext - WIP</h3>
   <gux-listbox value="b" aria-label="Animals">
     <gux-option-group title="Group label">
-      <gux-option value="a">Ant <span slot="subtext">Subtext</span></gux-option>
-      <gux-option value="b">Bat <span slot="subtext">Subtext</span></gux-option>
+      <gux-option value="a">Ant <span slot="subtext">...</span></gux-option>
+      <gux-option value="b">Bat <span slot="subtext">Squeak</span></gux-option>
+    </gux-option-group>
+    <gux-option-group title="Group 2 label">
+      <gux-option value="c">Cat <span slot="subtext">Meow</span></gux-option>
+      <gux-option value="d">Dog <span slot="subtext">Woof</span></gux-option>
+      <gux-option-icon
+        icon-name="user"
+        icon-color="var(--gux-blue-60)"
+        value="leonardo"
+        >Leonardo</gux-option-icon
+      >
     </gux-option-group>
   </gux-listbox>
 

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
@@ -195,11 +195,11 @@ export class GuxListbox {
       ) as ListboxOptionElement[];
     } else {
       const groups = Array.from(this.root.children);
-      groups.forEach(child => {
+      groups.map(child => {
         const childOptions = Array.from(
           child.children
         ) as ListboxOptionElement[];
-        this.listboxOptions = childOptions;
+        this.listboxOptions.push(...childOptions);
       });
     }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
@@ -184,6 +184,18 @@ export class GuxListbox {
     if (this.value) {
       this.selectedValues = this.value.split(',');
     }
+
+    const childrenArray = Array.from(this.root.children);
+    const options = [] as ListboxOptionElement[];
+    childrenArray.forEach(child => {
+      if (child.tagName === 'GUX-OPTION-GROUP') {
+        options.push(child.children as unknown as ListboxOptionElement);
+      } else {
+        options.push(child as unknown as ListboxOptionElement);
+      }
+    });
+    console.log(options);
+
     this.listboxOptions = Array.from(
       this.root.children
     ) as ListboxOptionElement[];

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
@@ -185,20 +185,24 @@ export class GuxListbox {
       this.selectedValues = this.value.split(',');
     }
 
-    const childrenArray = Array.from(this.root.children);
-    const options = [] as ListboxOptionElement[];
-    childrenArray.forEach(child => {
-      if (child.tagName === 'GUX-OPTION-GROUP') {
-        options.push(child.children as unknown as ListboxOptionElement);
-      } else {
-        options.push(child as unknown as ListboxOptionElement);
-      }
-    });
-    console.log(options);
+    const isGroupedList = Array.from(this.root.children).some(
+      child => child.tagName === 'GUX-OPTION-GROUP'
+    );
 
-    this.listboxOptions = Array.from(
-      this.root.children
-    ) as ListboxOptionElement[];
+    if (!isGroupedList) {
+      this.listboxOptions = Array.from(
+        this.root.children
+      ) as ListboxOptionElement[];
+    } else {
+      const groups = Array.from(this.root.children);
+      groups.forEach(child => {
+        const childOptions = Array.from(
+          child.children
+        ) as ListboxOptionElement[];
+        this.listboxOptions = childOptions;
+      });
+    }
+
     this.internallistboxoptionsupdated.emit();
   }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.tsx
@@ -1,0 +1,32 @@
+import { Component, h, Host, JSX, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'gux-option-group',
+  shadow: true
+})
+export class GuxOptionGroup {
+  /**
+   * Group title
+   */
+  @Prop()
+  title: string;
+
+  @Prop()
+  showDivider: boolean = true;
+
+  private renderDivider(): JSX.Element {
+    if (this.showDivider) {
+      return (<gux-list-divider></gux-list-divider>) as JSX.Element;
+    }
+  }
+
+  render(): JSX.Element {
+    return (
+      <Host role="group">
+        <div class="group-header">{this.title}</div>
+        <slot />
+        {this.renderDivider()}
+      </Host>
+    ) as JSX.Element;
+  }
+}

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.tsx
@@ -1,5 +1,11 @@
 import { Component, h, Host, JSX, Prop } from '@stencil/core';
 
+/**
+ * The listbox component provides keyboard bindings and a11y patterns for selecting
+ * from a list of options.
+ *
+ * @slot - collection of elements conforming to the ListboxOptionElement interface
+ */
 @Component({
   tag: 'gux-option-group',
   shadow: true

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.types.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/gux-option-group.types.ts
@@ -1,0 +1,4 @@
+export interface GuxOptionGroupElement extends HTMLElement {
+  title: string;
+  showDivider: boolean;
+}

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/option-group/readme.md
@@ -1,0 +1,10 @@
+# gux-option-group
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.tsx
@@ -6,10 +6,12 @@ import {
   JSX,
   Listen,
   Prop,
+  State,
   Watch
 } from '@stencil/core';
 
 import { randomHTMLId } from '@utils/dom/random-html-id';
+import { hasSlot } from '@utils/dom/has-slot';
 
 /**
  * @slot - text
@@ -27,9 +29,6 @@ export class GuxOptionIcon {
 
   @Prop()
   value: string;
-
-  @Prop()
-  subtext: string;
 
   @Prop()
   iconName: string;
@@ -55,6 +54,9 @@ export class GuxOptionIcon {
   @Prop({ mutable: true })
   hovered: boolean = false;
 
+  @State()
+  private hasSubtext: boolean = false;
+
   @Listen('mouseenter')
   onmouseenter() {
     this.hovered = true;
@@ -75,6 +77,7 @@ export class GuxOptionIcon {
 
   componentWillLoad(): void {
     this.root.id = this.root.id || randomHTMLId('gux-option-icon');
+    this.hasSubtext = hasSlot(this.root, 'subtext');
   }
 
   private getAriaSelected(): boolean | string {
@@ -86,13 +89,15 @@ export class GuxOptionIcon {
   }
 
   private renderText(): JSX.Element {
-    if (this.subtext) {
+    if (this.hasSubtext) {
       return (
         <div class="gux-option-text">
           <gux-truncate ref={el => (this.truncateElement = el)}>
             <slot />
           </gux-truncate>
-          <p>{this.subtext}</p>
+          <span>
+            <slot name="subtext"></slot>
+          </span>
         </div>
       ) as JSX.Element;
     } else {
@@ -121,7 +126,7 @@ export class GuxOptionIcon {
           'gux-filtered': this.filtered,
           'gux-hovered': this.hovered,
           'gux-selected': this.selected,
-          'gux-show-subtext': !!this.subtext
+          'gux-show-subtext': this.hasSubtext
         }}
         aria-selected={this.getAriaSelected()}
         aria-disabled={this.disabled.toString()}

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.tsx
@@ -29,6 +29,9 @@ export class GuxOptionIcon {
   value: string;
 
   @Prop()
+  subtext: string;
+
+  @Prop()
   iconName: string;
 
   @Prop()
@@ -82,6 +85,25 @@ export class GuxOptionIcon {
     return this.selected ? 'true' : 'false';
   }
 
+  private renderText(): JSX.Element {
+    if (this.subtext) {
+      return (
+        <div class="gux-option-text">
+          <gux-truncate ref={el => (this.truncateElement = el)}>
+            <slot />
+          </gux-truncate>
+          <p>{this.subtext}</p>
+        </div>
+      ) as JSX.Element;
+    } else {
+      return (
+        <gux-truncate ref={el => (this.truncateElement = el)}>
+          <slot />
+        </gux-truncate>
+      ) as JSX.Element;
+    }
+  }
+
   render(): JSX.Element {
     let iconStyle = null;
     // If the icon color is set and we don't have a background highlight that
@@ -98,7 +120,8 @@ export class GuxOptionIcon {
           'gux-disabled': this.disabled,
           'gux-filtered': this.filtered,
           'gux-hovered': this.hovered,
-          'gux-selected': this.selected
+          'gux-selected': this.selected,
+          'gux-show-subtext': !!this.subtext
         }}
         aria-selected={this.getAriaSelected()}
         aria-disabled={this.disabled.toString()}
@@ -109,9 +132,7 @@ export class GuxOptionIcon {
           icon-name={this.iconName}
           style={iconStyle}
         ></gux-icon>
-        <gux-truncate ref={el => (this.truncateElement = el)}>
-          <slot />
-        </gux-truncate>
+        {this.renderText()}
       </Host>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/readme.md
@@ -31,14 +31,14 @@
 
 ### Depends on
 
-- [gux-icon](../../../gux-icon)
 - [gux-truncate](../../../gux-truncate)
+- [gux-icon](../../../gux-icon)
 
 ### Graph
 ```mermaid
 graph TD;
-  gux-option-icon --> gux-icon
   gux-option-icon --> gux-truncate
+  gux-option-icon --> gux-icon
   gux-truncate --> gux-tooltip
   style gux-option-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
@@ -20,6 +20,9 @@ export class GuxOption {
   value: string;
 
   @Prop()
+  subtext: string;
+
+  @Prop()
   active: boolean = false;
 
   @Prop()
@@ -52,6 +55,25 @@ export class GuxOption {
     return this.selected ? 'true' : 'false';
   }
 
+  private renderText(): JSX.Element {
+    if (this.subtext) {
+      return (
+        <div class="gux-option-text">
+          <gux-truncate ref={el => (this.truncateElement = el)}>
+            <slot />
+          </gux-truncate>
+          <p>{this.subtext}</p>
+        </div>
+      ) as JSX.Element;
+    } else {
+      return (
+        <gux-truncate ref={el => (this.truncateElement = el)}>
+          <slot />
+        </gux-truncate>
+      ) as JSX.Element;
+    }
+  }
+
   render(): JSX.Element {
     return (
       <Host
@@ -60,14 +82,13 @@ export class GuxOption {
           'gux-active': this.active,
           'gux-disabled': this.disabled,
           'gux-filtered': this.filtered,
-          'gux-selected': this.selected
+          'gux-selected': this.selected,
+          'gux-show-subtext': !!this.subtext
         }}
         aria-selected={this.getAriaSelected()}
         aria-disabled={this.disabled.toString()}
       >
-        <gux-truncate ref={el => (this.truncateElement = el)}>
-          <slot />
-        </gux-truncate>
+        {this.renderText()}
       </Host>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
@@ -1,6 +1,16 @@
-import { Component, Element, h, Host, JSX, Prop, Watch } from '@stencil/core';
+import {
+  Component,
+  Element,
+  h,
+  Host,
+  JSX,
+  Prop,
+  State,
+  Watch
+} from '@stencil/core';
 
 import { randomHTMLId } from '@utils/dom/random-html-id';
+import { hasSlot } from '@utils/dom/has-slot';
 
 /**
  * @slot - text
@@ -20,9 +30,6 @@ export class GuxOption {
   value: string;
 
   @Prop()
-  subtext: string;
-
-  @Prop()
   active: boolean = false;
 
   @Prop()
@@ -33,6 +40,9 @@ export class GuxOption {
 
   @Prop()
   filtered: boolean = false;
+
+  @State()
+  hasSubtext: boolean = false;
 
   @Watch('active')
   handleActive(active: boolean) {
@@ -45,6 +55,7 @@ export class GuxOption {
 
   componentWillLoad(): void {
     this.root.id = this.root.id || randomHTMLId('gux-option');
+    this.hasSubtext = hasSlot(this.root, 'subtext');
   }
 
   private getAriaSelected(): boolean | string {
@@ -56,13 +67,15 @@ export class GuxOption {
   }
 
   private renderText(): JSX.Element {
-    if (this.subtext) {
+    if (this.hasSubtext) {
       return (
         <div class="gux-option-text">
           <gux-truncate ref={el => (this.truncateElement = el)}>
             <slot />
           </gux-truncate>
-          <p>{this.subtext}</p>
+          <span>
+            <slot name="subtext"></slot>
+          </span>
         </div>
       ) as JSX.Element;
     } else {
@@ -83,7 +96,7 @@ export class GuxOption {
           'gux-disabled': this.disabled,
           'gux-filtered': this.filtered,
           'gux-selected': this.selected,
-          'gux-show-subtext': !!this.subtext
+          'gux-show-subtext': this.hasSubtext
         }}
         aria-selected={this.getAriaSelected()}
         aria-disabled={this.disabled.toString()}

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
@@ -69,7 +69,7 @@ export class GuxOption {
   private renderText(): JSX.Element {
     if (this.hasSubtext) {
       return (
-        <div class="gux-option-text">
+        <div class="gux-option-wrapper">
           <gux-truncate ref={el => (this.truncateElement = el)}>
             <slot />
           </gux-truncate>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-defaults.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-defaults.scss
@@ -53,6 +53,16 @@
     outline-offset: -2px;
   }
 
+  :host(.gux-show-subtext) {
+    place-content: stretch flex-start;
+
+    .gux-option-text {
+      p {
+        margin: 0;
+      }
+    }
+  }
+
   :host(:hover:not(:disabled)) {
     background: var(--gse-ui-menu-option-hover-backgroundColor);
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-defaults.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-defaults.scss
@@ -55,11 +55,15 @@
 
   :host(.gux-show-subtext) {
     place-content: stretch flex-start;
+    height: auto;
 
-    .gux-option-text {
-      p {
-        margin: 0;
-      }
+    .gux-option-wrapper {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .gux-subtext {
+      color: #626e84; // need to clarify token.
     }
   }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-types.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-types.ts
@@ -30,5 +30,4 @@ export interface ListboxOptionElement extends HTMLElement {
   filtered: boolean;
   selected: boolean;
   value: string;
-  subtext: string;
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-types.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/option-types.ts
@@ -30,4 +30,5 @@ export interface ListboxOptionElement extends HTMLElement {
   filtered: boolean;
   selected: boolean;
   value: string;
+  subtext: string;
 }


### PR DESCRIPTION
As part of the change to menu component in GDS-2287, there's a request to display a subtext on a menu option. I've just put in a bare suggestion here of how I would implement this subtext. Feedback and suggestions welcome

Add subtext to option

Update: Now contains a rough example of option group as well. This approach would require maybe refactoring the listbox to accept gux-option-group as a child instead of just listboxoptionelements. Open to other ideas here

GDS-2287