### PR TITLE
fix(month-picker): popup positioning bug

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.scss
@@ -1,7 +1,6 @@
 .gux-month-calendar {
   flex-wrap: wrap;
   width: var(--gse-ui-calendarMenu-width);
-  height: var(--gse-ui-calendarMenu-height);
   box-shadow: var(--gse-ui-calendarMenu-boxShadow-x)
     var(--gse-ui-calendarMenu-boxShadow-y)
     var(--gse-ui-calendarMenu-boxShadow-blur)


### PR DESCRIPTION
This fixes the popup positioning issue identified in COMUI-2453 when the popup is placed above the `gux-month-picker`. I am not exactly sure why the height is affecting it not to reposition correctly but I also think we probably do not need a fixed height on the `gux-month-calendar`. We did not have a fixed height in `v3`

[COMUI-2453](https://inindca.atlassian.net/browse/COMUI-2453)

[COMUI-2453]: https://inindca.atlassian.net/browse/COMUI-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ