### PR TITLE
fix(gux-action-button): changed placement to bottom-end

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.tsx
@@ -191,6 +191,7 @@ export class GuxActionButton {
         <gux-popup
           expanded={this.isOpen}
           disabled={this.disabled}
+          placement="bottom-end"
           exceed-target-width
         >
           <div slot="target" class="gux-action-button-container">

--- a/packages/genesys-spark-components/src/components/stable/gux-action-button/tests/__snapshots__/gux-action-button.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-action-button/tests/__snapshots__/gux-action-button.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`gux-action-button renders 1`] = `
 <gux-action-button accent="primary" lang="en">
   <mock:shadow-root>
     <div class="gux-action-button-container">
-      <gux-popup exceed-target-width="">
+      <gux-popup exceed-target-width="" placement="bottom-end">
         <div class="gux-action-button-container" slot="target">
           <gux-button-slot accent="primary" class="gux-action-button">
             <button type="button">

--- a/packages/genesys-spark-components/src/components/stable/gux-button-multi/gux-button-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-button-multi/gux-button-multi.tsx
@@ -161,7 +161,11 @@ export class GuxButtonMulti {
 
   render(): JSX.Element {
     return (
-      <gux-popup expanded={this.isOpen} exceed-target-width>
+      <gux-popup
+        expanded={this.isOpen}
+        exceed-target-width
+        placement="bottom-end"
+      >
         <div slot="target" class="gux-button-multi-container">
           <gux-button-slot
             class="gux-dropdown-button"

--- a/packages/genesys-spark-components/src/components/stable/gux-popup/gux-popup.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popup/gux-popup.tsx
@@ -16,7 +16,8 @@ import {
   offset,
   size,
   shift,
-  hide
+  hide,
+  Placement
 } from '@floating-ui/dom';
 
 /**
@@ -32,6 +33,12 @@ export class GuxPopup {
   private targetElementContainer: HTMLElement;
   private popupElementContainer: HTMLElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
+
+  /**
+   * Placement of the popup. Default is bottom-start
+   */
+  @Prop()
+  placement: Placement = 'bottom-start';
 
   @Prop()
   expanded: boolean = false;
@@ -85,7 +92,7 @@ export class GuxPopup {
         this.popupElementContainer,
         {
           strategy: 'fixed',
-          placement: 'bottom-start',
+          placement: this.placement,
           middleware: [
             offset(this.offset),
             flip(),

--- a/packages/genesys-spark-components/src/components/stable/gux-popup/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-popup/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property            | Attribute             | Description                                                            | Type      | Default |
-| ------------------- | --------------------- | ---------------------------------------------------------------------- | --------- | ------- |
-| `disabled`          | `disabled`            |                                                                        | `boolean` | `false` |
-| `exceedTargetWidth` | `exceed-target-width` | set if parent component design allows for popup exceeding target width | `boolean` | `false` |
-| `expanded`          | `expanded`            |                                                                        | `boolean` | `false` |
-| `offset`            | `offset`              | Number of pixels the popup is offset from the target.                  | `number`  | `2`     |
+| Property            | Attribute             | Description                                                            | Type                                                                                                                                                                 | Default          |
+| ------------------- | --------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `disabled`          | `disabled`            |                                                                        | `boolean`                                                                                                                                                            | `false`          |
+| `exceedTargetWidth` | `exceed-target-width` | set if parent component design allows for popup exceeding target width | `boolean`                                                                                                                                                            | `false`          |
+| `expanded`          | `expanded`            |                                                                        | `boolean`                                                                                                                                                            | `false`          |
+| `offset`            | `offset`              | Number of pixels the popup is offset from the target.                  | `number`                                                                                                                                                             | `2`              |
+| `placement`         | `placement`           | Placement of the tooltip. Default is bottom-start                      | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
 
 
 ## Events


### PR DESCRIPTION
Added a `placement` property in `gux-popup` component and then passed `bottom-end` as the `placement` value to `gux-popup` from `gux-action-button` and `gux-button-multi`. This was done in order to right align the popup below these two components, instead of being left aligned before.

https://inindca.atlassian.net/browse/COMUI-2492