### PR TITLE
chore(jenkinsfile): add maintenance tag to v3 npm publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ webappPipeline {
                 withCredentials([
                   string(credentialsId: constants.credentials.npm,  variable: 'NPM_TOKEN')
                 ]) {
-                    sh(script: 'npm publish --workspace=packages/genesys-spark-components',
+                    sh(script: 'npm publish --tag maintenance --workspace=packages/genesys-spark-components',
                         label: 'Publish Components')
 
                     sh(script: '''
@@ -86,7 +86,7 @@ webappPipeline {
                         ''',
                         label: 'Set exact version dependency in React Components')
 
-                    sh(script: 'npm publish --workspace=packages/genesys-spark-components-react',
+                    sh(script: 'npm publish --tag maintenance --workspace=packages/genesys-spark-components-react',
                         label: 'Publish React Components')
                 }
             }

--- a/jenkinsfiles/components.Jenkinsfile
+++ b/jenkinsfiles/components.Jenkinsfile
@@ -86,7 +86,7 @@ webappPipeline {
                     sh('''
                       echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ./.npmrc
                       echo ".npmrc" >> .npmignore
-                      npm publish
+                      npm publish --tag maintenance
                     ''')
                 }
             }

--- a/jenkinsfiles/react.Jenkinsfile
+++ b/jenkinsfiles/react.Jenkinsfile
@@ -34,7 +34,7 @@ node(nodelabels.getCombinedExecutorLabelForEnv('dev')) {
                 npm install --legacy-peer-deps --no-progress --save --save-exact genesys-spark-components@${publishedVersion} &&
                 npm run build &&
                 npm version ${publishedVersion} &&
-                npm publish
+                npm publish --tag maintenance
             """
         }
     }

--- a/packages/genesys-spark-components-react/Jenkinsfile
+++ b/packages/genesys-spark-components-react/Jenkinsfile
@@ -29,7 +29,7 @@ node(nodelabels.getCombinedExecutorLabelForEnv('dev')) {
             sh(script: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ./packages/genesys-spark-components-react/.npmrc',
                 label: 'Set public npmjs registry with creds')
 
-            sh(script: 'npm publish --workspace=packages/genesys-spark-components-react',
+            sh(script: 'npm publish --tag maintenance --workspace=packages/genesys-spark-components-react',
                 label: 'Build project')
         }
     }


### PR DESCRIPTION
By default the published `maintenance/v3` versions are given the npm dist tag "latest". This conflicts with the v4 npm published versions, which are also being tagged as "latest". In this PR, I added the "maintenance" dist tag for npm publishes from the v3/maintenance branch.