### PR TITLE
chore(jenkinsfile): docs maintenance branch should not be MAINLINE build

### DIFF
--- a/web-apps/genesys-spark-examples/Jenkinsfile
+++ b/web-apps/genesys-spark-examples/Jenkinsfile
@@ -23,7 +23,7 @@ webappPipeline {
     skipCommitsFrom = []
     buildType = {
         if (isReleaseBranch) {
-            return 'MAINLINE'
+            return 'FEATURE'
         }
 
         return isFeatureBranch ? 'FEATURE' : 'CI'


### PR DESCRIPTION
I'm not sure if this one line change is enough to fix the issue we are having with the maintenance/v3 branch docs deploy. Any feedback is appreciated here