### PR TITLE
feat(toolbar) - fix table toolbar not condensing correctly

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.constants.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.constants.ts
@@ -1,5 +1,0 @@
-/**
- * Below is the minimum spacing in px that is required between,
- * the controls aligned to the left and controls aligned to the right.
- */
-export const MIN_CONTROL_SPACING = 72;


### PR DESCRIPTION
Identified that the container widths were not calculating correctly. For example if you were to console log `controlWidth` within the `recordLayoutMinSize` function onload you will get a width of `562px` which is incorrect and should be `590px`. By including a delay of `1` second when the component loads you will retrieve the correct widths.

This then lead to refactors to the resizing behaviour as it was not condensing correctly.

Open to suggestions on this change.

This will need to be **backported** also

https://inindca.atlassian.net/browse/COMUI-2581