### PR TITLE
fix(time-zone-picker): return closest city to user entry

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
@@ -76,20 +76,26 @@ export class GuxTimeZonePickerBeta {
   }
 
   private filterTimeZoneList(timeZoneList: GuxTimeZoneOption[]) {
-    const searchString = this.searchString;
+    const searchString = this.searchString.toLowerCase();
     return timeZoneList.filter(tzOption => {
-      return this.getFormattedTimeZoneOption(tzOption)
-        .toLowerCase()
-        .includes(searchString.toLowerCase());
+      return tzOption.mainCities.some(city => {
+        return tzOption.displayTextNameFormatted
+          .concat(tzOption.baseDisplayOffsetText)
+          .concat(city)
+          .toLowerCase()
+          .includes(searchString);
+      });
     });
   }
 
   private getTimeZoneOption(timeZone: GuxTimeZoneListing): GuxTimeZoneOption {
     const localizedGroupName = this.i18n(timeZone.name);
+
     const localizedCountryName = this.i18n(timeZone.countryName);
     if (!localizedGroupName) {
       return;
     }
+
     const formattedOffset = formatOffset(timeZone.currentTimeOffsetInMinutes);
     const localizedUTC = this.i18n('UTC');
     const displayTextName = `${localizedGroupName}`;
@@ -97,6 +103,7 @@ export class GuxTimeZonePickerBeta {
     const baseDisplayOffsetText = `${displayTextOffset}`;
     const displayTextNameFormatted = displayTextName.replace(/_/g, ' ');
     const countryName = `${localizedCountryName}`;
+    const mainCities = timeZone.mainCities;
     const defaultZone = '';
     const priority = displayTextName.startsWith('Etc/GMT') ? 2 : 1;
 
@@ -108,6 +115,7 @@ export class GuxTimeZonePickerBeta {
       displayTextOffset,
       baseDisplayOffsetText,
       countryName,
+      mainCities: mainCities,
       defaultZone,
       priority
     };

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
@@ -76,14 +76,13 @@ export class GuxTimeZonePickerBeta {
   }
 
   private filterTimeZoneList(timeZoneList: GuxTimeZoneOption[]) {
-    const searchString = this.searchString.toLowerCase();
     return timeZoneList.filter(tzOption => {
       return tzOption.mainCities.some(city => {
         return tzOption.displayTextName
           .concat(tzOption.baseDisplayOffsetText)
           .concat(city)
           .toLowerCase()
-          .includes(searchString);
+          .includes(this.searchString.toLowerCase());
       });
     });
   }

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
@@ -90,7 +90,6 @@ export class GuxTimeZonePickerBeta {
 
   private getTimeZoneOption(timeZone: GuxTimeZoneListing): GuxTimeZoneOption {
     const localizedGroupName = this.i18n(timeZone.name);
-
     const localizedCountryName = this.i18n(timeZone.countryName);
     if (!localizedGroupName) {
       return;

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
@@ -143,7 +143,9 @@ export class GuxTimeZonePickerBeta {
     return timeZoneOptionsList.sort(
       (a, b) =>
         a.priority - b.priority ||
-        a.displayTextName?.localeCompare(b.displayTextName)
+        this.getFormattedTimeZoneOption(a)?.localeCompare(
+          this.getFormattedTimeZoneOption(b)
+        )
     );
   }
 

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.tsx
@@ -79,7 +79,7 @@ export class GuxTimeZonePickerBeta {
     const searchString = this.searchString.toLowerCase();
     return timeZoneList.filter(tzOption => {
       return tzOption.mainCities.some(city => {
-        return tzOption.displayTextNameFormatted
+        return tzOption.displayTextName
           .concat(tzOption.baseDisplayOffsetText)
           .concat(city)
           .toLowerCase()
@@ -97,10 +97,9 @@ export class GuxTimeZonePickerBeta {
 
     const formattedOffset = formatOffset(timeZone.currentTimeOffsetInMinutes);
     const localizedUTC = this.i18n('UTC');
-    const displayTextName = `${localizedGroupName}`;
     const displayTextOffset = ` (${localizedUTC}${formattedOffset})`;
     const baseDisplayOffsetText = `${displayTextOffset}`;
-    const displayTextNameFormatted = displayTextName.replace(/_/g, ' ');
+    const displayTextName = `${localizedGroupName}`.replace(/_/g, ' ');
     const countryName = `${localizedCountryName}`;
     const mainCities = timeZone.mainCities;
     const defaultZone = '';
@@ -110,20 +109,20 @@ export class GuxTimeZonePickerBeta {
       value: timeZone.name,
       localizedGroupName,
       formattedOffset,
-      displayTextNameFormatted,
+      displayTextName,
       displayTextOffset,
       baseDisplayOffsetText,
       countryName,
-      mainCities: mainCities,
+      mainCities,
       defaultZone,
       priority
     };
   }
 
   private getFormattedTimeZoneOption(option: GuxTimeZoneOption): string {
-    return option.displayTextNameFormatted.startsWith('Etc/GMT')
-      ? option.displayTextNameFormatted.concat(option.baseDisplayOffsetText)
-      : option.displayTextNameFormatted
+    return option.displayTextName.startsWith('Etc/GMT')
+      ? option.displayTextName.concat(option.baseDisplayOffsetText)
+      : option.displayTextName
           .split('/')
           .pop()
           .concat(', ', option.countryName)
@@ -145,7 +144,7 @@ export class GuxTimeZonePickerBeta {
     return timeZoneOptionsList.sort(
       (a, b) =>
         a.priority - b.priority ||
-        a.displayTextNameFormatted?.localeCompare(b.displayTextNameFormatted)
+        a.displayTextName?.localeCompare(b.displayTextName)
     );
   }
 

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.types.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.types.ts
@@ -22,6 +22,7 @@ export interface GuxTimeZoneOption {
   displayTextOffset: string;
   baseDisplayOffsetText: string;
   countryName: string;
+  mainCities: string[];
   defaultZone: string;
   priority: number;
 }

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.types.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone-picker/gux-time-zone-picker.types.ts
@@ -18,7 +18,7 @@ export interface GuxTimeZoneOption {
   value: string;
   localizedGroupName: string;
   formattedOffset: string;
-  displayTextNameFormatted: string;
+  displayTextName: string;
   displayTextOffset: string;
   baseDisplayOffsetText: string;
   countryName: string;


### PR DESCRIPTION
This will return the closest city based on what the user is searching for. For example if you type `Barcelona` it will return `Madrid` which is the same timezone. Or for example if you type `San Jose` it will return `Los Angeles`.



I think this may be useful to backport also 🤔 

https://inindca.atlassian.net/browse/COMUI-2536