### PR TITLE
chore(gux-month-picker): region aware date formatting

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
@@ -14,6 +14,8 @@ import {
   GetI18nValue,
   getDesiredLocale
 } from '../../../../i18n';
+import * as sparkIntl from '../../../../genesys-spark-utils/intl';
+import { readRegionalDatesCookie } from '../../../../i18n/check-regional-dates-cookie';
 import simulateNativeEvent from '@utils/dom/simulate-native-event';
 import { afterNextRender } from '@utils/dom/after-next-render';
 import {
@@ -93,8 +95,11 @@ export class GuxMonthCalendar {
 
   async componentWillLoad(): Promise<void> {
     this.i18n = await buildI18nForComponent(this.root, translationResources);
-    this.locale = getDesiredLocale(this.root);
-
+    if (readRegionalDatesCookie()) {
+      this.locale = sparkIntl.determineDisplayLocale(this.root);
+    } else {
+      this.locale = getDesiredLocale(this.root);
+    }
     if (this.value) {
       this.year = getYearMonthObject(this.value).year;
     } else {

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
@@ -15,6 +15,7 @@ import {
   getDesiredLocale
 } from '../../../../i18n';
 import * as sparkIntl from '../../../../genesys-spark-utils/intl';
+// Remove with this ticket https://inindca.atlassian.net/browse/COMUI-2598
 import { readRegionalDatesCookie } from '../../../../i18n/check-regional-dates-cookie';
 import simulateNativeEvent from '@utils/dom/simulate-native-event';
 import { afterNextRender } from '@utils/dom/after-next-render';

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.tsx
@@ -17,6 +17,8 @@ import {
   GetI18nValue,
   getDesiredLocale
 } from '../../../i18n';
+import * as sparkIntl from '../../../genesys-spark-utils/intl';
+import { readRegionalDatesCookie } from '../../../i18n/check-regional-dates-cookie';
 import simulateNativeEvent from '@utils/dom/simulate-native-event';
 import { afterNextRender } from '@utils/dom/after-next-render';
 import {
@@ -109,7 +111,11 @@ export class GuxMonthPicker {
   async componentWillLoad(): Promise<void> {
     trackComponent(this.root);
     this.i18n = await buildI18nForComponent(this.root, translationResources);
-    this.locale = getDesiredLocale(this.root);
+    if (readRegionalDatesCookie()) {
+      this.locale = sparkIntl.determineDisplayLocale(this.root);
+    } else {
+      this.locale = getDesiredLocale(this.root);
+    }
   }
 
   private isOutOfBounds(value: GuxISOYearMonth): boolean {

--- a/packages/genesys-spark-components/src/genesys-spark-utils/get-closest-element.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/get-closest-element.ts
@@ -1,0 +1,23 @@
+//https://inindca.atlassian.net/browse/COMUI-2673
+export function closestPassShadow(
+  node: Element | ParentNode | null,
+  selector: string
+): HTMLElement | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node instanceof ShadowRoot) {
+    return closestPassShadow(node.host, selector);
+  }
+
+  if (node instanceof HTMLElement) {
+    if (node.matches(selector)) {
+      return node;
+    } else {
+      return closestPassShadow(node.parentNode, selector);
+    }
+  }
+
+  return closestPassShadow(node.parentNode, selector);
+}

--- a/packages/genesys-spark-components/src/genesys-spark-utils/get-closest-element.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/get-closest-element.ts
@@ -1,5 +1,5 @@
 //https://inindca.atlassian.net/browse/COMUI-2673
-export function closestPassShadow(
+export function getClosestElement(
   node: Element | ParentNode | null,
   selector: string
 ): HTMLElement | null {
@@ -8,16 +8,16 @@ export function closestPassShadow(
   }
 
   if (node instanceof ShadowRoot) {
-    return closestPassShadow(node.host, selector);
+    return getClosestElement(node.host, selector);
   }
 
   if (node instanceof HTMLElement) {
     if (node.matches(selector)) {
       return node;
     } else {
-      return closestPassShadow(node.parentNode, selector);
+      return getClosestElement(node.parentNode, selector);
     }
   }
 
-  return closestPassShadow(node.parentNode, selector);
+  return getClosestElement(node.parentNode, selector);
 }

--- a/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
@@ -7,7 +7,7 @@
  * @param options options to pass to the Intl.DateTimeFormat constructor
  * @returns a new DateTimeFormat
  */
-import { closestPassShadow } from './get-closest-element';
+import { getClosestElement } from './get-closest-element';
 export function dateTimeFormat(
   localeOrOptions: string | Intl.DateTimeFormatOptions,
   options?: Intl.DateTimeFormatOptions
@@ -65,7 +65,7 @@ export function relativeTimeFormat(
 export function determineDisplayLocale(
   element: HTMLElement = document.body
 ): string {
-  const domLocale = closestPassShadow(element, '*[lang]')?.lang;
+  const domLocale = getClosestElement(element, '*[lang]')?.lang;
   if (!domLocale || browserHasRegionData(domLocale)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.

--- a/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
@@ -7,6 +7,7 @@
  * @param options options to pass to the Intl.DateTimeFormat constructor
  * @returns a new DateTimeFormat
  */
+import { closestPassShadow } from './get-closest-element';
 export function dateTimeFormat(
   localeOrOptions: string | Intl.DateTimeFormatOptions,
   options?: Intl.DateTimeFormatOptions
@@ -53,28 +54,6 @@ export function relativeTimeFormat(
   }
 }
 
-function closestPassShadow(
-  node: Element | ParentNode | null,
-  selector: string
-): HTMLElement | null {
-  if (!node) {
-    return null;
-  }
-
-  if (node instanceof ShadowRoot) {
-    return closestPassShadow(node.host, selector);
-  }
-
-  if (node instanceof HTMLElement) {
-    if (node.matches(selector)) {
-      return node;
-    } else {
-      return closestPassShadow(node.parentNode, selector);
-    }
-  }
-
-  return closestPassShadow(node.parentNode, selector);
-}
 /**
  * Makes a best effort to return the locale that should be used for a given element
  * by checking language tags on ancestors. If no element is provided, it will

--- a/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
@@ -53,6 +53,28 @@ export function relativeTimeFormat(
   }
 }
 
+function closestPassShadow(
+  node: Element | ParentNode | null,
+  selector: string
+): HTMLElement | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node instanceof ShadowRoot) {
+    return closestPassShadow(node.host, selector);
+  }
+
+  if (node instanceof HTMLElement) {
+    if (node.matches(selector)) {
+      return node;
+    } else {
+      return closestPassShadow(node.parentNode, selector);
+    }
+  }
+
+  return closestPassShadow(node.parentNode, selector);
+}
 /**
  * Makes a best effort to return the locale that should be used for a given element
  * by checking language tags on ancestors. If no element is provided, it will
@@ -64,7 +86,7 @@ export function relativeTimeFormat(
 export function determineDisplayLocale(
   element: HTMLElement = document.body
 ): string {
-  const domLocale = element.closest<HTMLElement>('[lang]')?.lang;
+  const domLocale = closestPassShadow(element, '*[lang]')?.lang;
   if (!domLocale || browserHasRegionData(domLocale)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.

--- a/packages/genesys-spark/src/utils/get-closest-element.ts
+++ b/packages/genesys-spark/src/utils/get-closest-element.ts
@@ -1,5 +1,6 @@
 //https://inindca.atlassian.net/browse/COMUI-2673
-export function closestPassShadow(
+// utility to get the closest element passing shadow dom boundaries
+export function getClosestElement(
   node: Element | ParentNode | null,
   selector: string
 ): HTMLElement | null {
@@ -8,16 +9,16 @@ export function closestPassShadow(
   }
 
   if (node instanceof ShadowRoot) {
-    return closestPassShadow(node.host, selector);
+    return getClosestElement(node.host, selector);
   }
 
   if (node instanceof HTMLElement) {
     if (node.matches(selector)) {
       return node;
     } else {
-      return closestPassShadow(node.parentNode, selector);
+      return getClosestElement(node.parentNode, selector);
     }
   }
 
-  return closestPassShadow(node.parentNode, selector);
+  return getClosestElement(node.parentNode, selector);
 }

--- a/packages/genesys-spark/src/utils/get-closest-element.ts
+++ b/packages/genesys-spark/src/utils/get-closest-element.ts
@@ -1,0 +1,23 @@
+//https://inindca.atlassian.net/browse/COMUI-2673
+export function closestPassShadow(
+  node: Element | ParentNode | null,
+  selector: string
+): HTMLElement | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node instanceof ShadowRoot) {
+    return closestPassShadow(node.host, selector);
+  }
+
+  if (node instanceof HTMLElement) {
+    if (node.matches(selector)) {
+      return node;
+    } else {
+      return closestPassShadow(node.parentNode, selector);
+    }
+  }
+
+  return closestPassShadow(node.parentNode, selector);
+}

--- a/packages/genesys-spark/src/utils/intl.ts
+++ b/packages/genesys-spark/src/utils/intl.ts
@@ -7,7 +7,7 @@
  * @param options options to pass to the Intl.DateTimeFormat constructor
  * @returns a new DateTimeFormat
  */
-import { closestPassShadow } from './get-closest-element';
+import { getClosestElement } from './get-closest-element';
 export function dateTimeFormat(
   localeOrOptions: string | Intl.DateTimeFormatOptions,
   options?: Intl.DateTimeFormatOptions
@@ -65,7 +65,7 @@ export function relativeTimeFormat(
 export function determineDisplayLocale(
   element: HTMLElement = document.body
 ): string {
-  const domLocale = closestPassShadow(element, '*[lang]')?.lang;
+  const domLocale = getClosestElement(element, '*[lang]')?.lang;
   if (!domLocale || browserHasRegionData(domLocale)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.

--- a/packages/genesys-spark/src/utils/intl.ts
+++ b/packages/genesys-spark/src/utils/intl.ts
@@ -7,6 +7,7 @@
  * @param options options to pass to the Intl.DateTimeFormat constructor
  * @returns a new DateTimeFormat
  */
+import { closestPassShadow } from './get-closest-element';
 export function dateTimeFormat(
   localeOrOptions: string | Intl.DateTimeFormatOptions,
   options?: Intl.DateTimeFormatOptions
@@ -53,28 +54,6 @@ export function relativeTimeFormat(
   }
 }
 
-function closestPassShadow(
-  node: Element | ParentNode | null,
-  selector: string
-): HTMLElement | null {
-  if (!node) {
-    return null;
-  }
-
-  if (node instanceof ShadowRoot) {
-    return closestPassShadow(node.host, selector);
-  }
-
-  if (node instanceof HTMLElement) {
-    if (node.matches(selector)) {
-      return node;
-    } else {
-      return closestPassShadow(node.parentNode, selector);
-    }
-  }
-
-  return closestPassShadow(node.parentNode, selector);
-}
 /**
  * Makes a best effort to return the locale that should be used for a given element
  * by checking language tags on ancestors. If no element is provided, it will

--- a/packages/genesys-spark/src/utils/intl.ts
+++ b/packages/genesys-spark/src/utils/intl.ts
@@ -53,6 +53,28 @@ export function relativeTimeFormat(
   }
 }
 
+function closestPassShadow(
+  node: Element | ParentNode | null,
+  selector: string
+): HTMLElement | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node instanceof ShadowRoot) {
+    return closestPassShadow(node.host, selector);
+  }
+
+  if (node instanceof HTMLElement) {
+    if (node.matches(selector)) {
+      return node;
+    } else {
+      return closestPassShadow(node.parentNode, selector);
+    }
+  }
+
+  return closestPassShadow(node.parentNode, selector);
+}
 /**
  * Makes a best effort to return the locale that should be used for a given element
  * by checking language tags on ancestors. If no element is provided, it will
@@ -64,7 +86,7 @@ export function relativeTimeFormat(
 export function determineDisplayLocale(
   element: HTMLElement = document.body
 ): string {
-  const domLocale = element.closest<HTMLElement>('[lang]')?.lang;
+  const domLocale = closestPassShadow(element, '*[lang]')?.lang;
   if (!domLocale || browserHasRegionData(domLocale)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.


### PR DESCRIPTION
Date and time formatting should get now supplement region data from the browser.
This behavior is "feature toggled" using a cookie, called spark-enable-regional-dates. To test out the functionality, set document.cookie = 'spark-enable-regional-dates' in your console. 