### PR TITLE
chore(gux-time-picker): region aware date formatting

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.service.ts
@@ -1,4 +1,6 @@
 import { getDesiredLocale } from '../../../i18n';
+import * as sparkIntl from '../../../genesys-spark-utils/intl';
+import { readRegionalDatesCookie } from '../../../i18n/check-regional-dates-cookie';
 
 import {
   GuxClockType,
@@ -29,7 +31,12 @@ export function getTimeDisplayValues(
 }
 
 export function getLocaleClockType(root: HTMLElement): GuxClockType {
-  const locale = getDesiredLocale(root).toLowerCase();
+  let locale: string;
+  if (readRegionalDatesCookie()) {
+    locale = sparkIntl.determineDisplayLocale(root).toLowerCase();
+  } else {
+    locale = getDesiredLocale(root).toLowerCase();
+  }
   const date = new Date('January 19, 1975 15:00:00 UTC+00:00');
   const time = new Intl.DateTimeFormat(locale, {
     timeStyle: 'short',


### PR DESCRIPTION
Date and time formatting should get now supplement region data from the browser.
This behavior is "feature toggled" using a cookie, called spark-enable-regional-dates. To test out the functionality, set document.cookie = 'spark-enable-regional-dates' in your console. I opened a separate browser and set the region to "en-GB"  in my system preferences. To check the region in your console, just type navigator.language. As expected, the 24 hr time formats look different in my browser depending if I'm using en-US or en-GB regions.