### PR TITLE
fix(time-picker): AM/PM button does not inherit visibility css property when set on component

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.scss
@@ -86,12 +86,12 @@
       }
 
       .gux-meridiem {
+        display: none;
         grid-row: 1 / 1;
         grid-column: 1 / 1;
-        visibility: hidden;
 
         &.gux-visible {
-          visibility: visible;
+          display: inline-block;
         }
       }
     }


### PR DESCRIPTION
AM/PM button does not inherit visibility css property when set on component.

[COMUI-2659](https://inindca.atlassian.net/browse/COMUI-2659)

Needs to be **backported**

[COMUI-2659]: https://inindca.atlassian.net/browse/COMUI-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ