### PR TITLE
feat(gux-form-field-range): create and use internal tooltip component to share implementation

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.scss
@@ -1,0 +1,69 @@
+:host {
+  position: fixed;
+  z-index: var(--gse-semantic-zIndex-tooltip);
+  display: none;
+  width: max-content;
+  max-width: 250px;
+  pointer-events: none;
+  box-shadow: var(--gse-ui-tooltip-boxShadow-x)
+    var(--gse-ui-tooltip-boxShadow-y) var(--gse-ui-tooltip-boxShadow-blur)
+    var(--gse-ui-tooltip-boxShadow-spread) var(--gse-ui-tooltip-boxShadow-color);
+  opacity: 0;
+}
+
+:host(.gux-show) {
+  display: block;
+  animation-name: fade-in;
+  animation-duration: 250ms;
+  animation-delay: 1s;
+  animation-fill-mode: forwards;
+}
+
+.gux-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  gap: var(--gse-ui-tooltip-gap);
+  place-content: center flex-start;
+  padding: var(--gse-ui-tooltip-padding);
+  font-family: var(--gse-ui-tooltip-text-fontFamily);
+  font-size: var(--gse-ui-tooltip-text-fontSize);
+  font-weight: var(--gse-ui-tooltip-text-fontWeight);
+  line-height: var(--gse-ui-tooltip-text-lineHeight);
+  color: var(--gse-ui-tooltip-light-foregroundColor);
+  background-color: var(--gse-ui-tooltip-light-backgroundColor);
+  border: var(--gse-ui-tooltip-light-border-width)
+    var(--gse-ui-tooltip-light-border-style)
+    var(--gse-ui-tooltip-light-border-color);
+  border-radius: var(--gse-ui-tooltip-borderRadius);
+
+  ::slotted(gux-icon) {
+    align-self: center;
+    width: var(--gse-ui-icon-size-sm);
+    height: var(--gse-ui-icon-size-sm);
+    color: var(--gse-ui-tooltip-light-iconColor);
+  }
+
+  &.gux-dark {
+    color: var(--gse-ui-tooltip-dark-foregroundColor);
+    background-color: var(--gse-ui-tooltip-dark-backgroundColor);
+    border-color: var(--gse-ui-tooltip-dark-border-color);
+
+    ::slotted(gux-icon) {
+      align-self: center;
+      width: var(--gse-ui-icon-size-sm);
+      height: var(--gse-ui-icon-size-sm);
+      color: var(--gse-ui-tooltip-dark-iconColor);
+    }
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
@@ -1,0 +1,212 @@
+import {
+  Component,
+  Element,
+  h,
+  Host,
+  Listen,
+  JSX,
+  Method,
+  Prop,
+  State,
+  Watch
+} from '@stencil/core';
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  hide,
+  offset,
+  shift,
+  Placement
+} from '@floating-ui/dom';
+
+import { randomHTMLId } from '@utils/dom/random-html-id';
+import { trackComponent } from '@utils/tracking/usage';
+import { afterNextRender } from '@utils/dom/after-next-render';
+import { GuxTooltipAccent } from '../gux-tooltip-beta/gux-tooltip-types';
+
+/**
+ * @slot - Content of the tooltip
+ */
+@Component({
+  styleUrl: 'gux-tooltip-base.scss',
+  tag: 'gux-tooltip-base-beta',
+  shadow: true
+})
+export class GuxTooltipBase {
+  private pointerenterHandler: EventListener = () => this.show();
+  private pointerleaveHandler: EventListener = () => this.hide();
+  private focusinHandler: EventListener = () => this.show();
+  private focusoutHandler: EventListener = () => this.hide();
+
+  private forElementListeners: Map<string, EventListenerOrEventListenerObject> =
+    new Map([
+      ['pointerenter', this.pointerenterHandler],
+      ['pointerleave', this.pointerleaveHandler],
+      ['focusin', this.focusinHandler],
+      ['focusout', this.focusoutHandler]
+    ]);
+
+  private cleanupUpdatePosition: () => void;
+  private id: string = randomHTMLId('gux-tooltip-base');
+
+  @Element()
+  private root: HTMLElement;
+
+  @Prop()
+  tooltipId: string;
+
+  /**
+   * Indicates the element the popover should anchor to.
+   */
+  @Prop()
+  forElement: HTMLElement;
+
+  /**
+   * Placement of the tooltip. Default is bottom-start
+   */
+  @Prop({ mutable: true })
+  placement: Placement = 'bottom-start';
+
+  @Prop()
+  accent: GuxTooltipAccent = 'light';
+
+  /**
+   * If tooltip is shown or not
+   */
+  @State()
+  isShown: boolean = false;
+
+  @Listen('keydown', { target: 'window', passive: true })
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && this.isShown) {
+      this.hide();
+    }
+  }
+
+  /*
+   * Show tooltip
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @Method()
+  async showTooltip(): Promise<void> {
+    this.show();
+  }
+
+  /*
+   * Hide tooltip
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @Method()
+  async hideTooltip(): Promise<void> {
+    this.hide();
+  }
+
+  private runUpdatePosition(): void {
+    this.cleanupUpdatePosition = autoUpdate(
+      this.forElement,
+      this.root,
+      () => this.updatePosition(),
+      {
+        ancestorScroll: true,
+        elementResize: true,
+        animationFrame: false,
+        ancestorResize: true
+      }
+    );
+  }
+
+  private updatePosition(): void {
+    const middleware = [offset(16), flip(), shift(), hide()];
+
+    void computePosition(this.forElement, this.root, {
+      placement: this.placement,
+      strategy: 'fixed',
+      middleware: middleware
+    }).then(({ x, y, middlewareData }) => {
+      Object.assign(this.root.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+        visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible'
+      });
+      //data-placement needed on the for e2e tests.
+      this.root.setAttribute('data-placement', this.placement);
+    });
+  }
+  private show(): void {
+    this.isShown = true;
+    afterNextRender(() => {
+      this.runUpdatePosition();
+    });
+  }
+
+  private hide(): void {
+    if (this.cleanupUpdatePosition) {
+      this.cleanupUpdatePosition();
+    }
+    this.isShown = false;
+  }
+
+  private setForElement(): void {
+    if (this.forElement) {
+      const tooltipId = this.tooltipId ? this.tooltipId : this.id;
+      this.forElement.setAttribute('aria-describedby', tooltipId);
+
+      this.forElementListeners.forEach((handler, type) =>
+        this.forElement.addEventListener(type, handler)
+      );
+    }
+  }
+
+  private disconnectForElement(): void {
+    if (this.forElement) {
+      this.forElement.removeAttribute('aria-describedby');
+
+      this.forElementListeners.forEach((handler, type) =>
+        this.forElement.removeEventListener(type, handler)
+      );
+    }
+  }
+
+  @Watch('forElement') //@ts-expect-error: unused warning because is is only used by decorator
+  private updateForElement(): void {
+    this.disconnectForElement();
+    this.setForElement();
+  }
+
+  connectedCallback(): void {
+    this.setForElement();
+  }
+
+  componentWillLoad(): void {
+    trackComponent(this.root, { variant: this.placement });
+  }
+
+  disconnectedCallback(): void {
+    if (this.cleanupUpdatePosition) {
+      this.cleanupUpdatePosition();
+    }
+
+    this.disconnectForElement();
+  }
+
+  render(): JSX.Element {
+    return (
+      <Host
+        id={this.tooltipId ? undefined : this.id}
+        role={this.tooltipId ? undefined : 'tooltip'}
+        class={{ 'gux-show': this.isShown }}
+      >
+        <div
+          class={{
+            'gux-container': true,
+            [`gux-${this.accent}`]: true
+          }}
+          data-placement={this.placement}
+        >
+          <slot />
+        </div>
+      </Host>
+    ) as JSX.Element;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
@@ -68,6 +68,12 @@ export class GuxTooltipBase {
   @Prop({ mutable: true })
   placement: Placement = 'bottom-start';
 
+  @Prop({ mutable: true })
+  offsetX: number = 0;
+
+  @Prop({ mutable: true })
+  offsetY: number = 0;
+
   @Prop()
   accent: GuxTooltipAccent = 'light';
 
@@ -102,6 +108,8 @@ export class GuxTooltipBase {
     this.hide();
   }
 
+  @Watch('offsetX')
+  @Watch('offsetY')
   private runUpdatePosition(): void {
     this.cleanupUpdatePosition = autoUpdate(
       this.forElement,
@@ -125,8 +133,8 @@ export class GuxTooltipBase {
       middleware: middleware
     }).then(({ x, y, middlewareData }) => {
       Object.assign(this.root.style, {
-        left: `${x}px`,
-        top: `${y}px`,
+        left: `${x + this.offsetX}px`,
+        top: `${y - this.offsetY}px`,
         visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible'
       });
       //data-placement needed on the for e2e tests.

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/readme.md
@@ -1,0 +1,63 @@
+# gux-tooltip-base-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute    | Description                                         | Type                                                                                                                                                                 | Default          |
+| ------------ | ------------ | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `accent`     | `accent`     |                                                     | `"dark" \| "light"`                                                                                                                                                  | `'light'`        |
+| `forElement` | --           | Indicates the element the popover should anchor to. | `HTMLElement`                                                                                                                                                        | `undefined`      |
+| `placement`  | `placement`  | Placement of the tooltip. Default is bottom-start   | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
+| `tooltipId`  | `tooltip-id` |                                                     | `string`                                                                                                                                                             | `undefined`      |
+
+
+## Methods
+
+### `hideTooltip() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `showTooltip() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Slots
+
+| Slot | Description            |
+| ---- | ---------------------- |
+|      | Content of the tooltip |
+
+
+## Dependencies
+
+### Used by
+
+ - [gux-tooltip-beta](../gux-tooltip-beta)
+
+### Graph
+```mermaid
+graph TD;
+  gux-tooltip-beta --> gux-tooltip-base-beta
+  style gux-tooltip-base-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/a11yManualChecklist.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/a11yManualChecklist.md
@@ -1,0 +1,16 @@
+# gux-tooltip manual accessibility testing status
+
+**Last Updated:** Tue Dec 21 2021 15:29:59 GMT-0500 (Eastern Standard Time)
+| Pass | WCAG Success Criterion | Notes |
+| --- | --- | --- |
+| ✅ | [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html) | - |
+| ✅ | [2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html) | - |
+| ✅ | [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html) | - |
+| ✅ | [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) | - |
+| ✅ | [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html#dfn-name) | - |
+| ✅ | [3.2.1 On Focus](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html) | - |
+| ✅ | [3.2.2 On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) | - |
+| ✅ | [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html) | - |
+| ✅ | [3.2.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html) | - |
+| ❌ | [4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) | COMUI-819 tooltip text is not accessible to the screenreader |
+| ✅ | [4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html) | - |

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/example.html
@@ -1,0 +1,236 @@
+<h1>gux-tooltip-beta</h1>
+<h2>Summary</h2>
+<p>Simple tooltip that is displayed when hovering over a linked node.</p>
+
+<section>
+  <h3>Default Behavior</h3>
+  <p>
+    By default, the tooltip will be displayed when hovering over the parent
+    node. Default positioning is beneath the node. The tooltip is not restricted
+    by the parent's overflow style. If the text is sufficiently long, it will
+    wrap into multiple lines.
+  </p>
+
+  <p class="no-overflow">
+    <strong>Hover</strong> over this paragraph to see an example of a tooltip
+    extending beyond a node with hidden overflow.
+    <gux-tooltip-beta>Default behavior example</gux-tooltip-beta>
+  </p>
+
+  <p>
+    <strong>Hover</strong> over this paragraph to seen an example of a tooltip
+    with more text.
+    <gux-tooltip-beta
+      >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac odio a
+      dolor semper vehicula at ut nulla. Proin pellentesque neque sollicitudin
+      iaculis efficitur.</gux-tooltip-beta
+    >
+  </p>
+</section>
+
+<h2>Properties</h2>
+
+<section>
+  <h3>accent</h3>
+  <p>Applies styles for color variants.</p>
+  <div class="flex-container">
+    <div class="flex-example">
+      <h4 class="flex-header">light</h4>
+      <div class="flex-content">
+        <gux-button
+          >Hover<gux-tooltip-beta accent="light"
+            >Tooltip with light accent</gux-tooltip-beta
+          ></gux-button
+        >
+      </div>
+    </div>
+    <div class="flex-example">
+      <h4 class="flex-header">dark</h4>
+      <div class="flex-content">
+        <gux-button
+          >Hover<gux-tooltip-beta accent="dark"
+            >Tooltip with dark accent</gux-tooltip-beta
+          ></gux-button
+        >
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h3>for</h3>
+  <p>
+    Links the tooltip to an element by <em>id</em> instead of its parent node.
+  </p>
+  <div class="flex-container">
+    <div class="flex-example">
+      <h4 class="flex-header">Button</h4>
+      <div class="flex-content">
+        <gux-button id="button-example">Hover</gux-button>
+        <gux-tooltip-beta for="button-example"
+          >Tooltip for button</gux-tooltip-beta
+        >
+      </div>
+    </div>
+    <div class="flex-example">
+      <h4 class="flex-header">Icon</h4>
+      <div class="flex-content">
+        <gux-icon
+          id="icon-example"
+          icon-name="user-add"
+          screenreader-text="add John Smith to contact list"
+          >Hover
+        </gux-icon>
+        <gux-tooltip-beta for="icon-example">Tooltip for icon</gux-tooltip-beta>
+      </div>
+    </div>
+    <div class="flex-example">
+      <h4 class="flex-header">Text</h4>
+      <div class="flex-content">
+        <div>
+          Hover over the <strong id="text-example">highlighted</strong> text.
+        </div>
+        <gux-tooltip-beta for="text-example">Tooltip for text</gux-tooltip-beta>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h3>placement</h3>
+  <p>
+    Indicates preferred placement of the tooltip. Tooltip will shift based on
+    available space.
+  </p>
+  <div class="grid-example">
+    <div></div>
+    <div class="grid-content" id="top-start">top-start</div>
+    <div class="grid-content" id="top">top</div>
+    <div class="grid-content" id="top-end">top-end</div>
+    <div></div>
+    <div class="grid-content" id="left-start">left-start</div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div class="grid-content" id="right-start">right-start</div>
+    <div class="grid-content" id="left">left</div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div class="grid-content" id="right">right</div>
+    <div class="grid-content" id="left-end">left-end</div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div class="grid-content" id="right-end">right-end</div>
+    <div></div>
+    <div class="grid-content" id="bottom-start">bottom-start</div>
+    <div class="grid-content" id="bottom">bottom</div>
+    <div class="grid-content" id="bottom-end">bottom-end</div>
+    <div></div>
+
+    <gux-tooltip-beta for="top-start" placement="top-start"
+      >Top start tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="top" placement="top">Top tooltip</gux-tooltip-beta>
+    <gux-tooltip-beta for="top-end" placement="top-end"
+      >Top end tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="left-start" placement="left-start"
+      >Left start tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="right-start" placement="right-start"
+      >Right start tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="left" placement="left"
+      >Left tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="right" placement="right"
+      >Right tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="left-end" placement="left-end"
+      >Left end tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="right-end" placement="right-end"
+      >Right end tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="bottom-start" placement="bottom-start"
+      >Bottom start tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="bottom" placement="bottom"
+      >Bottom tooltip</gux-tooltip-beta
+    >
+    <gux-tooltip-beta for="bottom-end" placement="bottom-end"
+      >Bottom end tooltip</gux-tooltip-beta
+    >
+  </div>
+
+  <h2>Methods</h2>
+
+  <section>
+    <h3>hideTooltip</h3>
+    <code>hideTooltip() =&gt; Promise&lt;void&gt;</code>
+    <p>Hides the tooltip if it is currently visible.</p>
+  </section>
+
+  <section>
+    <h3>showTooltip</h3>
+    <code>showTooltip() =&gt; Promise&lt;void&gt;</code>
+    <p>Show the tooltip if it is currently hidden.</p>
+  </section>
+
+  <style>
+    .no-overflow {
+      position: relative;
+      overflow: hidden;
+    }
+
+    .flex-container {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .flex-example {
+      width: 250px;
+      min-width: 250px;
+    }
+
+    .flex-header {
+      width: fit-content;
+      margin: auto;
+      font-weight: 400;
+    }
+
+    .flex-content {
+      width: fit-content;
+      margin: auto;
+    }
+
+    .grid-example {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 25px;
+      width: 600px;
+      margin-left: 150px;
+    }
+
+    .grid-content {
+      padding: 20px 0;
+      font-weight: bold;
+      text-align: center;
+      background-color: aliceblue;
+      border: 1px solid lightblue;
+      border-radius: 5px;
+    }
+
+    p {
+      max-width: 600px;
+    }
+
+    strong {
+      background-color: yellow;
+    }
+  </style>
+</section>

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/gux-tooltip-types.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/gux-tooltip-types.ts
@@ -1,0 +1,1 @@
+export type GuxTooltipAccent = 'light' | 'dark';

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/gux-tooltip.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/gux-tooltip.tsx
@@ -1,0 +1,118 @@
+import {
+  Component,
+  Element,
+  h,
+  Host,
+  JSX,
+  Method,
+  Prop,
+  State,
+  Watch
+} from '@stencil/core';
+import { Placement } from '@floating-ui/dom';
+
+import { trackComponent } from '@utils/tracking/usage';
+import { GuxTooltipAccent } from './gux-tooltip-types';
+import { findElementById } from '@utils/dom/find-element-by-id';
+import { randomHTMLId } from '@utils/dom/random-html-id';
+
+/**
+ * @slot - Content of the tooltip
+ */
+@Component({
+  tag: 'gux-tooltip-beta',
+  shadow: true
+})
+export class GuxTooltip {
+  @Element()
+  private root: HTMLElement;
+  private baseTooltip: HTMLGuxTooltipBaseBetaElement;
+  private id: string = randomHTMLId('gux-tooltip');
+
+  @State()
+  private forElement: HTMLElement;
+
+  /**
+   * Indicates the id of the element the popover should anchor to. (If not supplied the parent element is used)
+   */
+  @Prop()
+  for: string;
+
+  /**
+   * Placement of the tooltip. Default is bottom-start
+   */
+  @Prop({ mutable: true })
+  placement: Placement = 'bottom-start';
+
+  @Prop()
+  accent: GuxTooltipAccent = 'light';
+
+  /*
+   * Show tooltip
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @Method()
+  async showTooltip(): Promise<void> {
+    return await this.baseTooltip.showTooltip();
+  }
+
+  /*
+   * Hide tooltip
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @Method()
+  async hideTooltip(): Promise<void> {
+    return await this.baseTooltip.hideTooltip();
+  }
+
+  @Watch('for') //@ts-expect-error: unused warning because is is only used by decorator
+  private updateForElement(): void {
+    this.forElement = this.getForElement();
+  }
+
+  componentWillLoad(): void {
+    trackComponent(this.root, { variant: this.placement });
+  }
+
+  connectedCallback(): void {
+    this.forElement = this.getForElement();
+  }
+
+  private getForElement(): HTMLElement {
+    if (this.for) {
+      const forElement = findElementById(this.root, this.for);
+
+      if (!forElement) {
+        this.logForAttributeError();
+      }
+
+      return forElement;
+    } else {
+      return this.root.parentElement;
+    }
+  }
+
+  private logForAttributeError(): void {
+    if (this.root.isConnected) {
+      console.error(
+        `gux-tooltip: invalid element supplied to 'for': "${this.for}"`
+      );
+    }
+  }
+
+  render(): JSX.Element {
+    return (
+      <Host id={this.id} role="tooltip">
+        <gux-tooltip-base-beta
+          forElement={this.forElement}
+          placement={this.placement}
+          accent={this.accent}
+          tooltipId={this.id}
+          ref={el => (this.baseTooltip = el)}
+        >
+          <slot />
+        </gux-tooltip-base-beta>
+      </Host>
+    ) as JSX.Element;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/readme.md
@@ -1,0 +1,80 @@
+# gux-tooltip
+
+This custom component is a simple tooltip.
+
+When hovering a node, the tooltip will be shown below.
+
+If there is not enough space on the bottom, or right of the component, the tooltip position will be adjusted.
+
+## Example usage
+
+``` html
+<!-- First option (With parentElement) -->
+<div>
+  <button>Button</button>
+  <gux-tooltip>My great tooltip</gux-tooltip>
+</div>
+
+<!-- Second option (With parent id in for attribute) -->
+<button id="needs-tooltip">Button</button>
+<gux-tooltip for="needs-tooltip">My great tooltip</gux-tooltip>
+```
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute   | Description                                                                                                | Type                                                                                                                                                                 | Default          |
+| ----------- | ----------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `accent`    | `accent`    |                                                                                                            | `"dark" \| "light"`                                                                                                                                                  | `'light'`        |
+| `for`       | `for`       | Indicates the id of the element the popover should anchor to. (If not supplied the parent element is used) | `string`                                                                                                                                                             | `undefined`      |
+| `placement` | `placement` | Placement of the tooltip. Default is bottom-start                                                          | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
+
+
+## Methods
+
+### `hideTooltip() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `showTooltip() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Slots
+
+| Slot | Description            |
+| ---- | ---------------------- |
+|      | Content of the tooltip |
+
+
+## Dependencies
+
+### Depends on
+
+- [gux-tooltip-base-beta](../gux-tooltip-base)
+
+### Graph
+```mermaid
+graph TD;
+  gux-tooltip-beta --> gux-tooltip-base-beta
+  style gux-tooltip-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/__snapshots__/gux-tooltip.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/__snapshots__/gux-tooltip.spec.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-tooltip-beta #remove should remove component as expected (1) 1`] = `
+<body>
+  <div>
+    <div>
+      Element
+    </div>
+  </div>
+</body>
+`;
+
+exports[`gux-tooltip-beta #remove should remove component as expected (2) 1`] = `
+<body>
+  <div>
+    <div id="element">
+      Element
+    </div>
+  </div>
+</body>
+`;
+
+exports[`gux-tooltip-beta #render should render component as expected (1) 1`] = `
+<body>
+  <div>
+    <div>
+      Element
+    </div>
+    <gux-tooltip-beta id="gux-tooltip-i" role="tooltip">
+      <mock:shadow-root>
+        <gux-tooltip-base-beta accent="light" placement="bottom-start" tooltipid="gux-tooltip-i">
+          <slot></slot>
+        </gux-tooltip-base-beta>
+      </mock:shadow-root>
+      Tooltip
+    </gux-tooltip-beta>
+  </div>
+</body>
+`;
+
+exports[`gux-tooltip-beta #render should render component as expected (2) 1`] = `
+<body>
+  <div>
+    <div id="element">
+      Element
+    </div>
+    <gux-tooltip-beta for="element" id="gux-tooltip-i" role="tooltip">
+      <mock:shadow-root>
+        <gux-tooltip-base-beta accent="light" placement="bottom-start" tooltipid="gux-tooltip-i">
+          <slot></slot>
+        </gux-tooltip-base-beta>
+      </mock:shadow-root>
+      Tooltip
+    </gux-tooltip-beta>
+  </div>
+</body>
+`;

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.e2e.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.e2e.ts
@@ -1,0 +1,40 @@
+import { newSparkE2EPage, a11yCheck } from '../../../../test/e2eTestUtils';
+
+describe('gux-tooltip-beta', () => {
+  describe('#render', () => {
+    [
+      `
+        <div id="element" lang="en">
+          <div>Element</div>
+          <gux-tooltip-beta>Tooltip</gux-tooltip-beta>
+        </div>
+      `,
+      `
+        <div lang="en">
+          <div id="element">Element</div>
+          <gux-tooltip-beta for="element">Tooltip</gux-tooltip-beta>
+        </div>
+      `
+    ].forEach((html, index) => {
+      it(`should render component as expected (${index + 1})`, async () => {
+        const page = await newSparkE2EPage({ html });
+
+        const element = await page.find('#element');
+        const tooltip = await page.find('gux-tooltip-beta');
+        const baseTooltip = await page.find(
+          'gux-tooltip-beta >>> gux-tooltip-base-beta'
+        );
+        expect(baseTooltip.className.split(' ')).not.toContain('gux-show');
+        await element.hover();
+        await page.waitForChanges();
+
+        await a11yCheck(page);
+
+        expect(element.getAttribute('aria-describedby')).toBe(tooltip.id);
+        expect(baseTooltip.className.split(' ')).toContain('gux-show');
+        expect(await baseTooltip.getProperty('placement')).toBe('bottom-start');
+        expect(tooltip).toHaveAttribute('hydrated');
+      });
+    });
+  });
+});

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.spec.ts
@@ -1,0 +1,63 @@
+import { newSpecPage } from '@test/specTestUtils';
+import { GuxTooltip } from '../gux-tooltip';
+
+const components = [GuxTooltip];
+const language = 'en';
+
+describe('gux-tooltip-beta', () => {
+  it('should build', async () => {
+    const html = '<gux-tooltip-beta></gux-tooltip-beta>';
+    const page = await newSpecPage({ components, html, language });
+
+    expect(page.rootInstance).toBeInstanceOf(GuxTooltip);
+  });
+
+  describe('#render', () => {
+    [
+      `
+        <div>
+          <div>Element</div>
+          <gux-tooltip-beta>Tooltip</gux-tooltip-beta>
+        </div>
+      `,
+      `
+        <div>
+          <div id="element">Element</div>
+          <gux-tooltip-beta for="element">Tooltip</gux-tooltip-beta>
+        </div>
+      `
+    ].forEach((html, index) => {
+      it(`should render component as expected (${index + 1})`, async () => {
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.body).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('#remove', () => {
+    [
+      `
+        <div>
+          <div>Element</div>
+          <gux-tooltip-beta>Tooltip</gux-tooltip-beta>
+        </div>
+      `,
+      `
+        <div>
+          <div id="element">Element</div>
+          <gux-tooltip-beta for="element">Tooltip</gux-tooltip-beta>
+        </div>
+      `
+    ].forEach((html, index) => {
+      it(`should remove component as expected (${index + 1})`, async () => {
+        const page = await newSpecPage({ components, html, language });
+
+        page.root.remove();
+        await page.waitForChanges();
+
+        expect(page.body).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.scss
@@ -73,6 +73,10 @@ $thumb-diameter: calc(var(--gse-ui-slider-handle-width) / 2);
 .gux-input-and-error-container {
   flex-grow: 1;
 
+  &.gux-hidden {
+    display: none;
+  }
+
   .gux-range-input-container {
     display: flex;
     flex-direction: row;
@@ -130,66 +134,6 @@ $thumb-diameter: calc(var(--gse-ui-slider-handle-width) / 2);
 
       &.gux-hidden {
         display: none;
-      }
-    }
-  }
-
-  // TODO: (COMUI-2234) Will circle back to update tooltip styles with tokens after the tooltip component is reskined
-  .gux-range-tooltip-container {
-    position: absolute;
-    top: -50px;
-    width: 100%;
-    height: 32px;
-    pointer-events: none;
-
-    &.gux-hidden {
-      display: none;
-    }
-
-    .gux-range-tooltip {
-      @include typography.body-sm-regular;
-
-      position: absolute;
-      z-index: var(--gse-semantic-zIndex-tooltip);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 50px;
-      height: 32px;
-      margin-left: -20px;
-      visibility: hidden;
-      background-color: var(--gse-ui-tooltip-light-backgroundColor);
-      border: var(--gse-ui-tooltip-light-border-width)
-        var(--gse-ui-tooltip-light-border-style)
-        var(--gse-ui-tooltip-light-border-color);
-      border-radius: var(--gse-ui-tooltip-borderRadius);
-      box-shadow: var(--gse-ui-tooltip-boxShadow-x)
-        var(--gse-ui-tooltip-boxShadow-y) var(--gse-ui-tooltip-boxShadow-blur)
-        var(--gse-ui-tooltip-boxShadow-spread)
-        var(--gse-ui-tooltip-boxShadow-color);
-
-      &::after,
-      &::before {
-        position: absolute;
-        top: 100%;
-        left: 50%;
-        width: 0;
-        height: 0;
-        pointer-events: none;
-        content: ' ';
-        border: solid transparent;
-      }
-
-      &::after {
-        margin-left: -4px;
-        border-width: 4px;
-        border-top-color: var(--gse-ui-tooltip-light-backgroundColor);
-      }
-
-      &::before {
-        margin-left: -6px;
-        border-width: 6px;
-        border-top-color: var(--gse-ui-tooltip-light-backgroundColor);
       }
     }
   }


### PR DESCRIPTION
Creates an internal, more powerful tooltip base component to share implementation between multiple components (currently only gux-tooltip and gux-form-field-range). This also removes arrow/ancho from the tooltip for the range component (that was removed from the design of the gux-tooltip) so there is a small visual change.