### PR TITLE
fix(gux-modal): added space around content slot

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
@@ -18,7 +18,8 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
   dialog {
     box-sizing: border-box;
     justify-content: space-between;
-    border: 1px solid #b4bccb; // TODO: COMUI-2300
+    padding: 0;
+    border: none;
     border-radius: var(--gse-ui-modal-borderRadius);
     box-shadow: var(--gse-ui-modal-boxShadow-x) var(--gse-ui-modal-boxShadow-y)
       var(--gse-ui-modal-boxShadow-blur) var(--gse-ui-modal-boxShadow-spread)
@@ -33,7 +34,8 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
     .gux-modal-container {
       display: flex;
       flex-direction: column;
-      padding: var(--gse-ui-modal-padding);
+      padding-top: var(--gse-ui-modal-padding);
+      padding-bottom: var(--gse-ui-modal-padding);
 
       &.gux-small {
         width: var(--gse-ui-modal-small-width);
@@ -60,6 +62,8 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
       }
 
       .gux-modal-header {
+        padding-right: var(--gse-ui-modal-padding);
+        padding-left: var(--gse-ui-modal-padding);
         margin: 0;
         font-family: var(--gse-ui-modal-heading-fontFamily);
         font-size: var(--gse-ui-modal-heading-fontSize);
@@ -73,6 +77,8 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
 
       .gux-modal-content {
         max-height: 432px;
+        padding-right: var(--gse-ui-modal-padding);
+        padding-left: var(--gse-ui-modal-padding);
         margin-top: var(--gse-ui-modal-gap);
         margin-bottom: var(--gse-ui-modal-gap);
         overflow-y: auto;
@@ -85,6 +91,8 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
       .gux-button-footer {
         display: flex;
         justify-content: space-between;
+        padding-right: var(--gse-ui-modal-padding);
+        padding-left: var(--gse-ui-modal-padding);
       }
     }
 


### PR DESCRIPTION
Closes https://inindca.atlassian.net/browse/COMUI-2690

I added 5px of padding to the right and left of the content slot. Doing this allows focusable elements to not be cut off on the left and right sides. I realize we could also ask the client to add spacing on their end instead of doing it inside the gux-modal component. Thoughts on adding spacing like I did and if so what kind of value makes sense? I feel like 5px is arbitrary. Should we use a token?

^^ **Update**: Daragh pushed a commit that makes the above not relevant anymore since the initial padding change I made had changed the design which we do not want.