### PR TITLE
fix(datepicker): first keypress after focus should be treated as new input

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -162,7 +162,7 @@ export class GuxDatepicker {
    * Tracks the amount of key presses when focusing on the input.
    */
   @State()
-  pressedKeys: Set<string> = new Set();
+  pressedKeys: Array<string> = [];
 
   @Watch('value')
   watchValue() {
@@ -246,6 +246,8 @@ export class GuxDatepicker {
           );
           this.setIntervalRange(previousIntervalRange);
           this.setCursorRange();
+          this.pressedKeys.length = 0;
+
           break;
         }
         case 'ArrowRight': {
@@ -257,6 +259,8 @@ export class GuxDatepicker {
           );
           this.setIntervalRange(nextIntervalRange);
           this.setCursorRange();
+          this.pressedKeys.length = 0;
+
           break;
         }
         default:
@@ -318,6 +322,7 @@ export class GuxDatepicker {
   @OnClickOutside({ triggerEvents: 'mousedown' })
   onClickOutside() {
     this.active = false;
+    this.pressedKeys.length = 0;
   }
 
   /*********  Event Handlers  **********/
@@ -331,7 +336,6 @@ export class GuxDatepicker {
   }
 
   onInputFocusOut() {
-    this.pressedKeys.clear();
     this.lastIntervalRange = this.initialIntervalRange;
   }
 
@@ -369,7 +373,7 @@ export class GuxDatepicker {
   }
 
   updateIntervalValue(event: KeyboardEvent): void {
-    this.pressedKeys.add(event.key);
+    this.pressedKeys.push(event.key);
     const inputNumber = parseInt(event.key, 10);
 
     if (!isNaN(inputNumber)) {
@@ -385,7 +389,7 @@ export class GuxDatepicker {
       ) {
         this.typeYearValue(currentSectionValue, event.key);
       } else {
-        if (this.canSetDate(inputNumber) && this.pressedKeys.size == 2) {
+        if (this.canSetDate(inputNumber) && this.pressedKeys.length >= 2) {
           this.updateSelection(
             this.focusedField,
             `${currentSectionValue[1]}${event.key}`
@@ -487,7 +491,7 @@ export class GuxDatepicker {
     }
   }
 
-  canSetDate(key: number) {
+  canSetDate(key: number): boolean {
     const newValue = parseInt(
       [
         this.focusedField.value[this.intervalRange.selectionEnd - 1].toString(),

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -158,6 +158,12 @@ export class GuxDatepicker {
   @State()
   active: boolean = false;
 
+  /**
+   * Tracks the amount of key presses when focusing on the input.
+   */
+  @State()
+  pressedKeys: Set<string> = new Set();
+
   @Watch('value')
   watchValue() {
     this.updateDate();
@@ -325,6 +331,7 @@ export class GuxDatepicker {
   }
 
   onInputFocusOut() {
+    this.pressedKeys.clear();
     this.lastIntervalRange = this.initialIntervalRange;
   }
 
@@ -362,6 +369,7 @@ export class GuxDatepicker {
   }
 
   updateIntervalValue(event: KeyboardEvent): void {
+    this.pressedKeys.add(event.key);
     const inputNumber = parseInt(event.key, 10);
 
     if (!isNaN(inputNumber)) {
@@ -377,7 +385,7 @@ export class GuxDatepicker {
       ) {
         this.typeYearValue(currentSectionValue, event.key);
       } else {
-        if (this.canSetDate(inputNumber)) {
+        if (this.canSetDate(inputNumber) && this.pressedKeys.size == 2) {
           this.updateSelection(
             this.focusedField,
             `${currentSectionValue[1]}${event.key}`


### PR DESCRIPTION
first keypress after focus should be treated as new input

To be **backported**

[COMUI-2616](https://inindca.atlassian.net/browse/COMUI-2616)

[COMUI-2616]: https://inindca.atlassian.net/browse/COMUI-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ