### PR TITLE
fix(tokens): add test command to package json

### DIFF
--- a/packages/genesys-spark-tokens/data/tokens.json
+++ b/packages/genesys-spark-tokens/data/tokens.json
@@ -8963,10 +8963,6 @@
           "type": "sizing"
         },
         "horizontal": {
-          "fixed_height": {
-            "value": "{size.xl}",
-            "type": "sizing"
-          },
           "padding": {
             "value": "11px {spacing.2xs} 10px",
             "type": "spacing"

--- a/packages/genesys-spark-tokens/data/tokens.json
+++ b/packages/genesys-spark-tokens/data/tokens.json
@@ -8963,6 +8963,10 @@
           "type": "sizing"
         },
         "horizontal": {
+          "fixed_height": {
+            "value": "{size.xl}",
+            "type": "sizing"
+          },
           "padding": {
             "value": "11px {spacing.2xs} 10px",
             "type": "spacing"

--- a/packages/genesys-spark-tokens/package.json
+++ b/packages/genesys-spark-tokens/package.json
@@ -15,7 +15,8 @@
     "prettier": "prettier --log-level silent --ignore-unknown --write .",
     "prettier-package-json": "prettier-package-json --write ./package.json",
     "snapshot": "node build/index.mjs snapshot",
-    "test": "node test/index.mjs"
+    "test": "node test/index.mjs",
+    "test.ci": "npm run test"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.1.1",

--- a/packages/genesys-spark/package.json
+++ b/packages/genesys-spark/package.json
@@ -16,6 +16,7 @@
     "lint-staged": "lint-staged --concurrent false",
     "prettier": "prettier --log-level silent --ignore-path .gitignore --ignore-unknown --write .",
     "test": "jest",
+    "test.ci": "npm run test",
     "test.watch": "jest --watch",
     "version-sync": "npm version --no-git-tag-version --allow-same-version"
   },


### PR DESCRIPTION
**Overview:**
We had an issue yesterday where I pushed a changed from the `genesys-spark-tokens` packages where I removed one item from the `tokens.json` and pushed to git and I never updated the snapshots but for some reason the build still passed. The general consensus is that there is no test commands within the tokens package json file therefore no failure would have been picked up. 

**Testing:**
I am going to test a **token change** on this PR without running new-tokens data and see if the build fails which is should.

**Update from testing:**
The build will now fail you can see my commit below in which it failed.

I think we should add the `new-tokens-data` to the build process if thats possible so that we dont encounter this issue ?

[COMUI-2719](https://inindca.atlassian.net/browse/COMUI-2719)

[COMUI-2719]: https://inindca.atlassian.net/browse/COMUI-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ