### PR TITLE
fix(month-picker): axe critical issues

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-list/gux-month-list.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-list/gux-month-list.tsx
@@ -67,14 +67,9 @@ export class GuxMonthList {
     first(this.root, validFocusableItems);
   }
 
-  private renderFocusTarget(): JSX.Element {
-    return (<span tabindex="1"></span>) as JSX.Element;
-  }
-
   render(): JSX.Element {
     return (
       <Host role="list">
-        {this.renderFocusTarget()}
         <slot></slot>
       </Host>
     ) as JSX.Element;

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/__snapshots__/gux-month-picker.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/__snapshots__/gux-month-picker.spec.ts.snap
@@ -33,7 +33,6 @@ exports[`gux-month-picker-beta #render should render the component as expected 1
             </div>
             <gux-month-list role="list" tabindex="1">
               <mock:shadow-root>
-                <span tabindex="1"></span>
                 <slot></slot>
               </mock:shadow-root>
               <gux-month-list-item aria-label="January 2022" aria-selected="true" role="listitem" value="2022-01">


### PR DESCRIPTION
These issues were found in the latest axe tools `4.8.4`. When reviewing there was 2 critical issues one was linked to the `aria-selected` on the `gux-month-list-item` component. I think this is valid and does not need to be removed. The other was linked to the `renderFocusTarget` method which renders a span with a `tabindex="1"`. I am not sure this is needed but I may be wrong but I could not figure what it was used for. This `renderFocusTarget` method is also used within the `gux-list` component.

I did a quick scan of other components and there seems to be critical issues in others also such as `tabs-advanced` maybe they can be addressed in a separate ticket ?

[COMUI-2417](https://inindca.atlassian.net/browse/COMUI-2417)

[COMUI-2417]: https://inindca.atlassian.net/browse/COMUI-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ