### PR TITLE
feat(modal): allow modal to be reopened

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
@@ -84,7 +84,7 @@ export class GuxModal {
     switch (event.key) {
       case 'Escape':
         event.preventDefault();
-        this.dialogElement.close();
+        this.open = false;
         return;
     }
   }
@@ -168,6 +168,6 @@ export class GuxModal {
   }
 
   private onDismissHandler(): void {
-    this.dialogElement.close();
+    this.open = false;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
@@ -84,7 +84,7 @@ export class GuxModal {
     switch (event.key) {
       case 'Escape':
         event.preventDefault();
-        this.open = false;
+        this.onDismissHandler();
         return;
     }
   }


### PR DESCRIPTION
On the docs site, the modal can't be reopened once closed as closing doesn't change the this.open prop.