### PR TITLE
fix(gux-accordion): allowing user to highlight text

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.scss
@@ -1,7 +1,4 @@
 :host {
-  -webkit-user-select: none;
-  user-select: none;
-
   &:first-child {
     .gux-header {
       border-top: var(--gse-ui-accordion-wrapper-dividerBorder-width)


### PR DESCRIPTION
Closes https://inindca.atlassian.net/browse/COMUI-2763

The user was not able to highlight/select text in the accordion content and header, which is now fixed.