### PR TITLE
fix(tabs-advanced): Closing popover list on tab press

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
@@ -78,6 +78,7 @@ export class GuxPopoverList {
   @Listen('keydown')
   onKeyDown(event: KeyboardEvent): void {
     switch (event.key) {
+      case 'Tab':
       case 'Escape':
         this.dismiss();
         break;


### PR DESCRIPTION
✅ Closes: COMUI-2735

Closing popover-list on tab key press. Before, pressing the tab key would not close the popover-list within a tabs-advanced component.

Here's a video showing how you can test this functionality. The way I test it is tabbing to a 3 vertical dot icon in one of the tab headers and pressing enter, and then hitting tab again to try and focus out of the popover-list component. The bug I fixed was only present when using the keyboard to navigate to the popover-list, rather than using the mouse which didn't cause the bug to appear.

https://github.com/MyPureCloud/genesys-spark/assets/127438502/92429cb6-e74b-4c5c-a8bf-25e0f02733e3

