### PR TITLE
fix(popover): Closing popover on focus out

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -86,6 +86,20 @@ export class GuxPopover {
     }
   }
 
+  @Listen('focusout')
+  onFocusout(event: FocusEvent): void {
+    if (!this.closeOnClickOutside && this.displayDismissButton) {
+      return;
+    }
+
+    const focusIsOutsidePopover = !this.root.contains(
+      event.relatedTarget as Node
+    );
+    if (focusIsOutsidePopover) {
+      this.dismiss();
+    }
+  }
+
   @OnClickOutside({ triggerEvents: 'mousedown' })
   checkForClickOutside(event: MouseEvent) {
     const clickPath = event.composedPath();


### PR DESCRIPTION
✅ Closes: COMUI-1636

For now, you can paste this for the example page content to test the functionality added for this PR.

To test this PR, you can move focus into an element in the popover using the tab key to get there, and then move focus out of the popover by using the tab key or shift + tab and you should see the popover become hidden when you move focus out of the popover.

```
<h1>gux-popover</h1>
<div class="scroll-container">
  <div class="scroll-interior">
    <div id="popover-target">Example Element</div>
    <gux-popover
      id="popover-example"
      position="top"
      for="popover-target"
      is-open
    >
      <span slot="title">Title</span>
      <div class="popover-content-wrapper">
        <div>Popover Content</div>
        <div class="popover-content">
          <gux-button accent="ghost" onclick="notify(event)">
            Action 3
          </gux-button>
          <gux-button accent="secondary" onclick="notify(event)">
            Action 2
          </gux-button>
          <gux-button accent="primary" onclick="notify(event)">
            Action 1
          </gux-button>
        </div>
      </div>
    </gux-popover>
  </div>
</div>

<style
  onload="(function () {
  const popoverTarget = document.getElementById('popover-target');
  const popoverExample = document.getElementById('popover-example');

  popoverTarget.addEventListener('mouseover', () => {
    popoverExample.isOpen = true;
  });
})()"
>
  .scroll-container {
    width: 900px;
    height: 300px;
    margin: auto;
    overflow: scroll;
    border: 1px solid #aaa;
  }

  .scroll-interior {
    position: relative;
    width: 600px;
    height: 600px;
    background-color: #fff;
  }

  .popover-content-wrapper {
    display: flex;
    flex-direction: column;
    gap: 16px;
  }

  .popover-content {
    display: flex;
    flex-direction: row;
    gap: 8px;
    width: 280px;
  }

  #popover-target {
    position: absolute;
    top: 250px;
    left: 250px;
    display: inline-block;
    padding: 10px 15px;
    background-color: #fdfdfd;
    border: 1px #e4e9f0;
    box-shadow: 0 0 2px fade(#202937, 24%);
  }
</style>
```