### PR TITLE
feat(modal): using css to show or hide the button footer

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
@@ -80,12 +80,7 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
         padding-right: var(--gse-ui-modal-padding);
         padding-left: var(--gse-ui-modal-padding);
         margin-top: var(--gse-ui-modal-gap);
-        margin-bottom: var(--gse-ui-modal-gap);
         overflow-y: auto;
-
-        &.gux-no-buttons {
-          margin-bottom: 0;
-        }
       }
 
       .gux-button-footer {
@@ -93,6 +88,11 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
         justify-content: space-between;
         padding-right: var(--gse-ui-modal-padding);
         padding-left: var(--gse-ui-modal-padding);
+        margin-top: var(--gse-ui-modal-gap);
+
+        &.gux-no-buttons {
+          margin-top: 0;
+        }
       }
     }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
@@ -91,7 +91,7 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
         margin-top: var(--gse-ui-modal-gap);
 
         &.gux-no-buttons {
-          margin-top: 0;
+          display: none;
         }
       }
     }

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
@@ -132,7 +132,7 @@ export class GuxModal {
 
           {hasModalTitleSlot && this.renderTitle(titleID)}
 
-          <div class="'gux-modal-content">
+          <div class="gux-modal-content">
             <p>
               <slot name="content" />
             </p>

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.tsx
@@ -102,15 +102,21 @@ export class GuxModal {
   }
 
   private hasFooterButtons(): boolean {
+    const startAlignButtonsSlot = this.root.querySelector(
+      '[slot="start-align-buttons"]'
+    );
+    const endAlignButtonsSlot = this.root.querySelector(
+      '[slot="end-align-buttons"]'
+    );
+
     return (
-      Boolean(this.root.querySelector('[slot="start-align-buttons"]')) ||
-      Boolean(this.root.querySelector('[slot="end-align-buttons"]'))
+      Boolean(startAlignButtonsSlot?.textContent?.trim()) ||
+      Boolean(endAlignButtonsSlot?.textContent?.trim())
     );
   }
 
   render(): JSX.Element {
     const hasModalTitleSlot = this.hasModalTitleSlot();
-    const hasFooterButtons = this.hasFooterButtons();
     const titleID: string = randomHTMLId();
 
     return (
@@ -126,17 +132,12 @@ export class GuxModal {
 
           {hasModalTitleSlot && this.renderTitle(titleID)}
 
-          <div
-            class={{
-              'gux-modal-content': true,
-              'gux-no-buttons': !hasFooterButtons
-            }}
-          >
+          <div class="'gux-modal-content">
             <p>
               <slot name="content" />
             </p>
           </div>
-          {hasFooterButtons && this.renderButtonFooter()}
+          {this.renderButtonFooter()}
         </div>
       </dialog>
     ) as JSX.Element;
@@ -151,8 +152,14 @@ export class GuxModal {
   }
 
   private renderButtonFooter(): JSX.Element {
+    const hasFooterButtons = this.hasFooterButtons();
     return (
-      <div class="gux-button-footer">
+      <div
+        class={{
+          'gux-button-footer': true,
+          'gux-no-buttons': !hasFooterButtons
+        }}
+      >
         <div class="gux-start-align-buttons">
           <slot name="start-align-buttons" />
         </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/tests/__snapshots__/gux-modal.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/tests/__snapshots__/gux-modal.spec.ts.snap
@@ -350,10 +350,18 @@ exports[`gux-modal #render should render modal without buttons 1`] = `
         <h1 class="gux-modal-header" id="gux-i">
           <slot name="title"></slot>
         </h1>
-        <div class="gux-modal-content gux-no-buttons">
+        <div class="gux-modal-content">
           <p>
             <slot name="content"></slot>
           </p>
+        </div>
+        <div class="gux-button-footer gux-no-buttons">
+          <div class="gux-start-align-buttons">
+            <slot name="start-align-buttons"></slot>
+          </div>
+          <div class="gux-end-align-buttons">
+            <slot name="end-align-buttons"></slot>
+          </div>
         </div>
       </div>
     </dialog>


### PR DESCRIPTION
Instead of conditionally rendering footer slots this change will render the slots & hide using CSS where appropriate.