### PR TITLE
feat(table): improving table row hover

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
@@ -18,12 +18,6 @@ gux-table {
       color: var(--gse-ui-dataTableItems-cell-foregroundColor);
       text-align: left;
 
-      &:hover {
-        background-color: var(
-          --gse-ui-dataTableItems-cell-hoverBackgroundColor
-        );
-      }
-
       gux-icon {
         color: var(--gse-ui-dataTableItems-cell-icon-foregroundColor);
       }
@@ -101,15 +95,10 @@ gux-table {
 
       tr:nth-child(2n) {
         background-color: var(--gse-ui-dataTableItems-cell-altBackgroundColor);
-
-        &:hover {
-          background-color: var(
-            --gse-ui-dataTableItems-cell-hoverBackgroundColor
-          );
-        }
       }
 
-      tr:hover {
+      tr:hover,
+      tr:nth-child(2n):hover {
         background-color: var(
           --gse-ui-dataTableItems-cell-hoverBackgroundColor
         );

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
@@ -101,6 +101,12 @@ gux-table {
 
       tr:nth-child(2n) {
         background-color: var(--gse-ui-dataTableItems-cell-altBackgroundColor);
+
+        &:hover {
+          background-color: var(
+            --gse-ui-dataTableItems-cell-hoverBackgroundColor
+          );
+        }
       }
 
       tr:hover {


### PR DESCRIPTION
Additional CSS rule to make the table row hover on the darker rows more robust & difficult to override.