### PR TITLE
fix(popup): correct placement of popup now occurs on load

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popup/gux-popup.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popup/gux-popup.tsx
@@ -147,9 +147,7 @@ export class GuxPopup {
   }
 
   componentDidLoad(): void {
-    if (this.expanded) {
-      this.runUpdatePosition();
-    }
+    this.runUpdatePosition();
   }
 
   componentDidUpdate(): void {


### PR DESCRIPTION
correct placement of popup now occurs on load

**Notes**
When a component using popup loads the initial position of the popup is in the incorrect place if you inspect the DOM which can cause issues. This is due to the fact that the updating of the position only occurs when the popup is in an expanded state.

I removed the `if` guard from the `componentDidLoad()` lifecycle to resolve this. I dont think this causes any regressions.

✅ Closes: COMUI-2883