### PR TITLE
feat(dropdown): Options for selected option flexibility 

### DIFF
--- a/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/gux-pagination-items-per-page-legacy/tests/__snapshots__/gux-pagination-items-per-page.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/gux-pagination-items-per-page-legacy/tests/__snapshots__/gux-pagination-items-per-page.spec.ts.snap
@@ -30,6 +30,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -41,6 +42,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -52,6 +54,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -63,6 +66,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -110,6 +114,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -121,6 +126,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -132,6 +138,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -143,6 +150,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -190,6 +198,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -201,6 +210,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -212,6 +222,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -223,6 +234,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -270,6 +282,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -281,6 +294,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -292,6 +306,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -303,6 +318,7 @@ exports[`gux-pagination-items-per-page-legacy #render should render as expected 
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>

--- a/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/tests/__snapshots__/gux-pagination.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/tests/__snapshots__/gux-pagination.spec.ts.snap
@@ -44,6 +44,7 @@ exports[`gux-pagination-legacy #render should render as expected (1) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -55,6 +56,7 @@ exports[`gux-pagination-legacy #render should render as expected (1) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -66,6 +68,7 @@ exports[`gux-pagination-legacy #render should render as expected (1) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -77,6 +80,7 @@ exports[`gux-pagination-legacy #render should render as expected (1) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -188,6 +192,7 @@ exports[`gux-pagination-legacy #render should render as expected (2) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -199,6 +204,7 @@ exports[`gux-pagination-legacy #render should render as expected (2) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -210,6 +216,7 @@ exports[`gux-pagination-legacy #render should render as expected (2) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -221,6 +228,7 @@ exports[`gux-pagination-legacy #render should render as expected (2) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -332,6 +340,7 @@ exports[`gux-pagination-legacy #render should render as expected (3) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -343,6 +352,7 @@ exports[`gux-pagination-legacy #render should render as expected (3) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -354,6 +364,7 @@ exports[`gux-pagination-legacy #render should render as expected (3) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -365,6 +376,7 @@ exports[`gux-pagination-legacy #render should render as expected (3) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -476,6 +488,7 @@ exports[`gux-pagination-legacy #render should render as expected (4) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -487,6 +500,7 @@ exports[`gux-pagination-legacy #render should render as expected (4) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -498,6 +512,7 @@ exports[`gux-pagination-legacy #render should render as expected (4) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -509,6 +524,7 @@ exports[`gux-pagination-legacy #render should render as expected (4) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -620,6 +636,7 @@ exports[`gux-pagination-legacy #render should render as expected (5) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -631,6 +648,7 @@ exports[`gux-pagination-legacy #render should render as expected (5) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -642,6 +660,7 @@ exports[`gux-pagination-legacy #render should render as expected (5) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -653,6 +672,7 @@ exports[`gux-pagination-legacy #render should render as expected (5) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -764,6 +784,7 @@ exports[`gux-pagination-legacy #render should render as expected (6) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -775,6 +796,7 @@ exports[`gux-pagination-legacy #render should render as expected (6) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -786,6 +808,7 @@ exports[`gux-pagination-legacy #render should render as expected (6) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -797,6 +820,7 @@ exports[`gux-pagination-legacy #render should render as expected (6) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -908,6 +932,7 @@ exports[`gux-pagination-legacy #render should render as expected (7) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -919,6 +944,7 @@ exports[`gux-pagination-legacy #render should render as expected (7) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -930,6 +956,7 @@ exports[`gux-pagination-legacy #render should render as expected (7) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -941,6 +968,7 @@ exports[`gux-pagination-legacy #render should render as expected (7) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1052,6 +1080,7 @@ exports[`gux-pagination-legacy #render should render as expected (8) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1063,6 +1092,7 @@ exports[`gux-pagination-legacy #render should render as expected (8) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1074,6 +1104,7 @@ exports[`gux-pagination-legacy #render should render as expected (8) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1085,6 +1116,7 @@ exports[`gux-pagination-legacy #render should render as expected (8) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1196,6 +1228,7 @@ exports[`gux-pagination-legacy #render should render as expected (9) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1207,6 +1240,7 @@ exports[`gux-pagination-legacy #render should render as expected (9) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1218,6 +1252,7 @@ exports[`gux-pagination-legacy #render should render as expected (9) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1229,6 +1264,7 @@ exports[`gux-pagination-legacy #render should render as expected (9) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1392,6 +1428,7 @@ exports[`gux-pagination-legacy #render should render as expected (11) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1403,6 +1440,7 @@ exports[`gux-pagination-legacy #render should render as expected (11) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1414,6 +1452,7 @@ exports[`gux-pagination-legacy #render should render as expected (11) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1425,6 +1464,7 @@ exports[`gux-pagination-legacy #render should render as expected (11) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1536,6 +1576,7 @@ exports[`gux-pagination-legacy #render should render as expected (12) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1547,6 +1588,7 @@ exports[`gux-pagination-legacy #render should render as expected (12) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1558,6 +1600,7 @@ exports[`gux-pagination-legacy #render should render as expected (12) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1569,6 +1612,7 @@ exports[`gux-pagination-legacy #render should render as expected (12) 1`] = `
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1680,6 +1724,7 @@ exports[`gux-pagination-legacy #render should render current page as 1 when tota
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1691,6 +1736,7 @@ exports[`gux-pagination-legacy #render should render current page as 1 when tota
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1702,6 +1748,7 @@ exports[`gux-pagination-legacy #render should render current page as 1 when tota
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>
@@ -1713,6 +1760,7 @@ exports[`gux-pagination-legacy #render should render current page as 1 when tota
                     <mock:shadow-root>
                       <div class="gux-option-wrapper">
                         <gux-truncate>
+                          <slot name="text"></slot>
                           <slot></slot>
                         </gux-truncate>
                         <slot name="subtext"></slot>

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/example.html
@@ -476,11 +476,21 @@
   <gux-dropdown value="">
     <gux-listbox value="a" aria-label="Animals">
       <gux-option value="a" disabled
-        >Ant <span slot="subtext">Very Small</span></gux-option
+        ><span slot="text">Ant</span>
+        <span slot="subtext">Very Small</span></gux-option
       >
-      <gux-option value="b">Bat<span slot="subtext">Small</span></gux-option>
-      <gux-option value="c">Cat<span slot="subtext">Medium</span></gux-option>
-      <gux-option value="d">Dog<span slot="subtext">Large</span></gux-option>
+      <gux-option value="b"
+        ><span slot="text">Bat</span
+        ><span slot="subtext">Small</span></gux-option
+      >
+      <gux-option value="c"
+        ><span slot="text">Cat</span
+        ><span slot="subtext">Medium</span></gux-option
+      >
+      <gux-option value="d"
+        ><span slot="text">Dog</span
+        ><span slot="subtext">Large</span></gux-option
+      >
     </gux-listbox>
   </gux-dropdown>
 

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -20,6 +20,7 @@ import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-c
 import { afterNextRender } from '@utils/dom/after-next-render';
 import { trackComponent } from '@utils/tracking/usage';
 import { OnMutation } from '@utils/decorator/on-mutation';
+import { getSlotTextContent } from '@utils/dom/get-slot-text-content';
 
 import translationResources from './i18n/en.json';
 
@@ -421,13 +422,10 @@ export class GuxDropdown {
 
   private renderOption(option: HTMLGuxOptionElement): JSX.Element {
     let optionText = option.textContent;
-    if (hasSlot(option, 'subtext')) {
-      const subtext = option.querySelector('[slot=subtext]');
-      optionText = optionText.substring(
-        0,
-        optionText.length - subtext.textContent.length
-      );
+    if (hasSlot(option, 'text')) {
+      optionText = getSlotTextContent(option, 'text');
     }
+
     return (
       <gux-truncate ref={el => (this.truncateElement = el)}>
         {optionText}

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -422,8 +422,15 @@ export class GuxDropdown {
 
   private renderOption(option: HTMLGuxOptionElement): JSX.Element {
     let optionText = option.textContent;
+    // TODO: COMUI-2909 Look at removing this subtext clause
     if (hasSlot(option, 'text')) {
       optionText = getSlotTextContent(option, 'text');
+    } else if (hasSlot(option, 'subtext')) {
+      const subtext = option.querySelector('[slot=subtext]');
+      optionText = optionText.substring(
+        0,
+        optionText.length - subtext.textContent.length
+      );
     }
 
     return (

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/__snapshots__/gux-dropdown.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/__snapshots__/gux-dropdown.spec.ts.snap
@@ -25,6 +25,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -39,6 +40,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -50,6 +52,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -61,6 +64,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -72,6 +76,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -83,6 +88,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -94,6 +100,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -105,6 +112,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -119,6 +127,7 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
       <mock:shadow-root>
         <div class="gux-option-wrapper">
           <gux-truncate>
+            <slot name="text"></slot>
             <slot></slot>
           </gux-truncate>
           <slot name="subtext"></slot>
@@ -169,6 +178,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -180,6 +190,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -191,6 +202,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -202,6 +214,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -226,6 +239,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -237,6 +251,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -248,6 +263,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -272,6 +288,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -283,6 +300,7 @@ exports[`gux-dropdown #render should render as expected with gux-option-group an
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
@@ -167,6 +167,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help should rende
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -178,6 +179,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help should rende
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -189,6 +191,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help should rende
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1007,6 +1010,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1018,6 +1022,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1029,6 +1034,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1099,6 +1105,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1110,6 +1117,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1121,6 +1129,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1194,6 +1203,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1205,6 +1215,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1216,6 +1227,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1286,6 +1298,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1297,6 +1310,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1308,6 +1322,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1378,6 +1393,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1389,6 +1405,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1400,6 +1417,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1470,6 +1488,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1481,6 +1500,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1492,6 +1512,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1562,6 +1583,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1573,6 +1595,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>
@@ -1584,6 +1607,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
         <mock:shadow-root>
           <div class="gux-option-wrapper">
             <gux-truncate>
+              <slot name="text"></slot>
               <slot></slot>
             </gux-truncate>
             <slot name="subtext"></slot>

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option/gux-option.tsx
@@ -87,6 +87,7 @@ export class GuxOption {
       >
         <div class="gux-option-wrapper">
           <gux-truncate ref={el => (this.truncateElement = el)}>
+            <slot name="text" />
             <slot />
           </gux-truncate>
           <slot onSlotchange={() => this.onSubtextChange()} name="subtext" />

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-items-per-page/tests/__snapshots__/gux-pagination-items-per-page.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-items-per-page/tests/__snapshots__/gux-pagination-items-per-page.spec.ts.snap
@@ -30,6 +30,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (1) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -41,6 +42,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (1) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -52,6 +54,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (1) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -63,6 +66,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (1) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -110,6 +114,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (2) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -121,6 +126,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (2) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -132,6 +138,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (2) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -143,6 +150,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (2) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -190,6 +198,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (3) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -201,6 +210,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (3) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -212,6 +222,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (3) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -223,6 +234,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (3) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -270,6 +282,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (4) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -281,6 +294,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (4) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -292,6 +306,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (4) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>
@@ -303,6 +318,7 @@ exports[`gux-pagination-items-per-page #render should render as expected (4) 1`]
             <mock:shadow-root>
               <div class="gux-option-wrapper">
                 <gux-truncate>
+                  <slot name="text"></slot>
                   <slot></slot>
                 </gux-truncate>
                 <slot name="subtext"></slot>


### PR DESCRIPTION
This is a discussion PR for a way to try and make the gux-option a little bit more flexible without impacting the text shown for the dropdown selected item. 

There were some challenges with the current approach. One was an issue the other day with the subtext for gux-option (which is undone here). The other also involved an attempt as adding supplementary info via tooltip. In both cases, because we currently just grab the gux-option textContent, the selected option in the dropdown didn't look correct. 

Any thoughts welcome. 

✅ Closes: COMUI-2736