### PR TITLE
feat(table): applying styles to whole row even with sticky columns

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/example.html
@@ -992,12 +992,4 @@
   .gux-sticky-cell-header-style {
     background-color: var(--gse-ui-dataTableItems-header-fixedBackgroundColor);
   }
-
-  .gux-sticky-cell-style-odd {
-    background-color: var(--gse-ui-dataTableItems-cell-altBackgroundColor);
-  }
-
-  .gux-sticky-cell-style-even {
-    background-color: var(--gse-ui-dataTableItems-cell-defaultBackgroundColor);
-  }
 </style>

--- a/packages/genesys-spark-components/src/components/stable/gux-table/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/example.html
@@ -866,8 +866,8 @@
     </thead>
     <tbody>
       <tr>
-        <td class="gux-sticky-cell gux-sticky-cell-style-even">John</td>
-        <td class="gux-sticky-cell-2 gux-sticky-cell-style-even">Doe</td>
+        <td class="gux-sticky-cell">John</td>
+        <td class="gux-sticky-cell-2">Doe</td>
         <td>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
@@ -881,8 +881,8 @@
         <td data-cell-action>Delete</td>
       </tr>
       <tr>
-        <td class="gux-sticky-cell gux-sticky-cell-style-odd">Jane</td>
-        <td class="gux-sticky-cell-2 gux-sticky-cell-style-odd">Doe</td>
+        <td class="gux-sticky-cell">Jane</td>
+        <td class="gux-sticky-cell-2">Doe</td>
         <td>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
@@ -896,8 +896,8 @@
         <td data-cell-action>Delete</td>
       </tr>
       <tr>
-        <td class="gux-sticky-cell gux-sticky-cell-style-even">Jane</td>
-        <td class="gux-sticky-cell-2 gux-sticky-cell-style-even">Doe</td>
+        <td class="gux-sticky-cell">Jane</td>
+        <td class="gux-sticky-cell-2">Doe</td>
         <td>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
@@ -911,8 +911,8 @@
         <td data-cell-action>Delete</td>
       </tr>
       <tr>
-        <td class="gux-sticky-cell gux-sticky-cell-style-odd">Jane</td>
-        <td class="gux-sticky-cell-2 gux-sticky-cell-style-odd">Doe</td>
+        <td class="gux-sticky-cell">Jane</td>
+        <td class="gux-sticky-cell-2">Doe</td>
         <td>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.light.scss
@@ -87,18 +87,18 @@ gux-table {
     }
 
     tbody {
-      tr {
+      tr td {
         background-color: var(
           --gse-ui-dataTableItems-cell-defaultBackgroundColor
         );
       }
 
-      tr:nth-child(2n) {
+      tr:nth-child(2n) td {
         background-color: var(--gse-ui-dataTableItems-cell-altBackgroundColor);
       }
 
-      tr:hover,
-      tr:nth-child(2n):hover {
+      tr:hover td,
+      tr:nth-child(2n):hover td {
         background-color: var(
           --gse-ui-dataTableItems-cell-hoverBackgroundColor
         );


### PR DESCRIPTION
This will provide default & hover colours on table rows even when sticky removing the necessity to add them separately.