### PR TITLE
fix(pagination): remove legacy types import

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
@@ -13,7 +13,8 @@ import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
 
 import translationResources from './i18n/en.json';
 import { GuxPaginationCursorDetail } from './gux-pagination-cursor.types';
-import { GuxItemsPerPage } from '../../legacy/gux-pagination-legacy/gux-pagination.types';
+
+import { GuxItemsPerPage } from '../gux-pagination/gux-pagination.types';
 
 @Component({
   styleUrl: 'gux-pagination-cursor.scss',

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination.tsx
@@ -17,10 +17,9 @@ import { trackComponent } from '@utils/tracking/usage';
 
 import {
   GuxItemsPerPage,
+  GuxPaginationLayout,
   GuxPaginationState
-} from '../../legacy/gux-pagination-legacy/gux-pagination.types';
-
-import { GuxPaginationLayout } from './gux-pagination.types';
+} from './gux-pagination.types';
 
 const minAdvancedSpacerWidth = 24;
 

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination.types.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination.types.ts
@@ -1,3 +1,8 @@
 export type GuxPaginationLayout = 'simple' | 'advanced';
 
 export type GuxItemsPerPage = 25 | 50 | 75 | 100;
+
+export type GuxPaginationState = {
+  currentPage: number;
+  itemsPerPage: number;
+};


### PR DESCRIPTION
**Note**
Prior to `V4` beta imported from stable and after `V4` stable became legacy and beta became stable so that is the reason for the current stable importing from legacy but is no longer needed as legacy will be outdated.

✅ Closes: COMUI-2888