### PR TITLE
docs(tooltip-beta): fixing invalid html

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/example.html
@@ -15,7 +15,7 @@
     <strong>Hover</strong> over this paragraph to see an example of a tooltip
     extending beyond a node with hidden overflow.
     <gux-tooltip-beta>
-      <div slot="content">Default behavior example</div>
+      <span slot="content">Default behavior example</span>
     </gux-tooltip-beta>
   </p>
 
@@ -23,11 +23,11 @@
     <strong>Hover</strong> over this paragraph to seen an example of a tooltip
     with more text.
     <gux-tooltip-beta>
-      <div slot="content">
+      <span slot="content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac odio a
         dolor semper vehicula at ut nulla. Proin pellentesque neque sollicitudin
         iaculis efficitur.
-      </div>
+      </span>
     </gux-tooltip-beta>
   </p>
 </section>

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/__snapshots__/gux-tooltip.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/__snapshots__/gux-tooltip.spec.ts.snap
@@ -36,9 +36,9 @@ exports[`gux-tooltip-beta #render should render component as expected (1) 1`] = 
           </span>
         </gux-tooltip-base-beta>
       </mock:shadow-root>
-      <div slot="content">
+      <span slot="content">
         Tooltip
-      </div>
+      </span>
     </gux-tooltip-beta>
   </div>
 </body>

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.e2e.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.e2e.ts
@@ -7,7 +7,7 @@ describe('gux-tooltip-beta', () => {
         <div id="element" lang="en">
           <div>Element</div>
           <gux-tooltip-beta>
-            <div slot="content">Tooltip</div>
+            <span slot="content">Tooltip</span>
           </gux-tooltip-beta>
         </div>
       `,

--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-beta/tests/gux-tooltip.spec.ts
@@ -18,7 +18,7 @@ describe('gux-tooltip-beta', () => {
         <div>
           <div>Element</div>
           <gux-tooltip-beta>
-            <div slot="content">Tooltip</div>
+            <span slot="content">Tooltip</span>
           </gux-tooltip-beta>
         </div>
       `,
@@ -45,7 +45,7 @@ describe('gux-tooltip-beta', () => {
         <div>
           <div>Element</div>
           <gux-tooltip-beta>
-            <div slot="content">Tooltip</div>
+            <span slot="content">Tooltip</span>
           </gux-tooltip-beta>
         </div>
       `,


### PR DESCRIPTION
A div cannot be nested inside a paragraph, replacing with span.