### PR TITLE
chore(form-field-checkbox): Design changes for error message and icon

### DIFF
--- a/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/gux-pagination-buttons-legacy/tests/__snapshots__/gux-pagination-buttons.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/gux-pagination-buttons-legacy/tests/__snapshots__/gux-pagination-buttons.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`gux-pagination-item-counts-legacy #render should render as expected (1)
                   </div>
                 </div>
                 <div class="gux-form-field-error">
-                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
                   <div class="gux-message">
                     <slot name="error"></slot>
                   </div>
@@ -109,7 +109,7 @@ exports[`gux-pagination-item-counts-legacy #render should render as expected (2)
                   </div>
                 </div>
                 <div class="gux-form-field-error">
-                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
                   <div class="gux-message">
                     <slot name="error"></slot>
                   </div>
@@ -183,7 +183,7 @@ exports[`gux-pagination-item-counts-legacy #render should render as expected (3)
                   </div>
                 </div>
                 <div class="gux-form-field-error">
-                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+                  <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
                   <div class="gux-message">
                     <slot name="error"></slot>
                   </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -43,7 +43,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -75,7 +75,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -110,7 +110,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -142,7 +142,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -177,7 +177,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (6)
         <div class="gux-label-beside">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`gux-form-field-color #render help should render component as expected 1
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -51,7 +51,7 @@ exports[`gux-form-field-color #render input attributes should render component a
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -85,7 +85,7 @@ exports[`gux-form-field-color #render input attributes should render component a
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -119,7 +119,7 @@ exports[`gux-form-field-color #render input attributes should render component a
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -153,7 +153,7 @@ exports[`gux-form-field-color #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -187,7 +187,7 @@ exports[`gux-form-field-color #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -221,7 +221,7 @@ exports[`gux-form-field-color #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -255,7 +255,7 @@ exports[`gux-form-field-color #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help multi select
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -130,7 +130,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help should rende
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -225,7 +225,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -331,7 +331,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -440,7 +440,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -546,7 +546,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -652,7 +652,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -758,7 +758,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -864,7 +864,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -970,7 +970,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1062,7 +1062,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1157,7 +1157,7 @@ exports[`gux-form-field-dropdown single select dropdown #render input attributes
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1249,7 +1249,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1341,7 +1341,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1433,7 +1433,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -1525,7 +1525,7 @@ exports[`gux-form-field-dropdown single select dropdown #render label-position s
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`gux-form-field-number #render clearable should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -65,7 +65,7 @@ exports[`gux-form-field-number #render clearable should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -108,7 +108,7 @@ exports[`gux-form-field-number #render clearable should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -150,7 +150,7 @@ exports[`gux-form-field-number #render clearable should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -192,7 +192,7 @@ exports[`gux-form-field-number #render clearable should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -234,7 +234,7 @@ exports[`gux-form-field-number #render help should render component as expected 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -279,7 +279,7 @@ exports[`gux-form-field-number #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -321,7 +321,7 @@ exports[`gux-form-field-number #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -363,7 +363,7 @@ exports[`gux-form-field-number #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -405,7 +405,7 @@ exports[`gux-form-field-number #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -447,7 +447,7 @@ exports[`gux-form-field-number #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -489,7 +489,7 @@ exports[`gux-form-field-number #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -531,7 +531,7 @@ exports[`gux-form-field-number #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-phone/tests/__snapshots__/gux-form-field-phone.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-phone/tests/__snapshots__/gux-form-field-phone.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`gux-form-field-phone #render error should render component as expected 
           </div>
         </div>
         <div class="gux-form-field-error gux-show">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -66,7 +66,7 @@ exports[`gux-form-field-phone #render help should render component as expected 1
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -109,7 +109,7 @@ exports[`gux-form-field-phone #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -149,7 +149,7 @@ exports[`gux-form-field-phone #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -189,7 +189,7 @@ exports[`gux-form-field-phone #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -229,7 +229,7 @@ exports[`gux-form-field-phone #render label-position should render component as 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`gux-form-field-radio #render should render component as expected (1) 1`
         <div aria-disabled="false" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -43,7 +43,7 @@ exports[`gux-form-field-radio #render should render component as expected (2) 1`
         <div aria-disabled="true" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -75,7 +75,7 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
         <div aria-disabled="false" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -110,7 +110,7 @@ exports[`gux-form-field-radio #render should render component as expected (4) 1`
         <div aria-disabled="false" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -142,7 +142,7 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
         <div aria-disabled="false" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -177,7 +177,7 @@ exports[`gux-form-field-radio #render should render component as expected (6) 1`
         <div aria-disabled="true" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error gux-show">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -212,7 +212,7 @@ exports[`gux-form-field-radio #render should render component as expected (7) 1`
         <div aria-disabled="false" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>
@@ -247,7 +247,7 @@ exports[`gux-form-field-radio #render should render component as expected (8) 1`
         <div aria-disabled="true" class="gux-label">
           <slot name="label"></slot>
           <div class="gux-form-field-error">
-            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+            <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
             </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`gux-form-field-search #render help should render component as expected 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -54,7 +54,7 @@ exports[`gux-form-field-search #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -89,7 +89,7 @@ exports[`gux-form-field-search #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -125,7 +125,7 @@ exports[`gux-form-field-search #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -161,7 +161,7 @@ exports[`gux-form-field-search #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -197,7 +197,7 @@ exports[`gux-form-field-search #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -233,7 +233,7 @@ exports[`gux-form-field-search #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -269,7 +269,7 @@ exports[`gux-form-field-search #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`gux-form-field-select #render help should render component as expected 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -63,7 +63,7 @@ exports[`gux-form-field-select #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -108,7 +108,7 @@ exports[`gux-form-field-select #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -153,7 +153,7 @@ exports[`gux-form-field-select #render input attributes should render component 
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -198,7 +198,7 @@ exports[`gux-form-field-select #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -243,7 +243,7 @@ exports[`gux-form-field-select #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -288,7 +288,7 @@ exports[`gux-form-field-select #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -333,7 +333,7 @@ exports[`gux-form-field-select #render label-position should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -53,7 +53,7 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -90,7 +90,7 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -126,7 +126,7 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -162,7 +162,7 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -198,7 +198,7 @@ exports[`gux-form-field-text-like #render help should render component as expect
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -237,7 +237,7 @@ exports[`gux-form-field-text-like #render input attributes should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -273,7 +273,7 @@ exports[`gux-form-field-text-like #render input attributes should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -309,7 +309,7 @@ exports[`gux-form-field-text-like #render input attributes should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -345,7 +345,7 @@ exports[`gux-form-field-text-like #render input type attribute should render com
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -381,7 +381,7 @@ exports[`gux-form-field-text-like #render input type attribute should render com
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -417,7 +417,7 @@ exports[`gux-form-field-text-like #render input type attribute should render com
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -453,7 +453,7 @@ exports[`gux-form-field-text-like #render label-position should render component
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -489,7 +489,7 @@ exports[`gux-form-field-text-like #render label-position should render component
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -525,7 +525,7 @@ exports[`gux-form-field-text-like #render label-position should render component
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -561,7 +561,7 @@ exports[`gux-form-field-text-like #render label-position should render component
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -597,7 +597,7 @@ exports[`gux-form-field-text-like #render loading should render component as exp
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -634,7 +634,7 @@ exports[`gux-form-field-text-like #render loading should render component as exp
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -671,7 +671,7 @@ exports[`gux-form-field-text-like #render loading should render component as exp
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -707,7 +707,7 @@ exports[`gux-form-field-text-like #render loading should render component as exp
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -744,7 +744,7 @@ exports[`gux-form-field-text-like #render loading should render component as exp
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -780,7 +780,7 @@ exports[`gux-form-field-text-like #render prefix should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -819,7 +819,7 @@ exports[`gux-form-field-text-like #render suffix should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`gux-form-field-textarea #render help should render component as expecte
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -46,7 +46,7 @@ exports[`gux-form-field-textarea #render input attributes should render componen
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -77,7 +77,7 @@ exports[`gux-form-field-textarea #render input attributes should render componen
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -108,7 +108,7 @@ exports[`gux-form-field-textarea #render input attributes should render componen
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -139,7 +139,7 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -170,7 +170,7 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -201,7 +201,7 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -232,7 +232,7 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -263,7 +263,7 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -294,7 +294,7 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -325,7 +325,7 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -356,7 +356,7 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <slot name="input"></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`gux-form-field-time-picker #render help should render component as expe
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -73,7 +73,7 @@ exports[`gux-form-field-time-picker #render intervals should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -118,7 +118,7 @@ exports[`gux-form-field-time-picker #render intervals should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -163,7 +163,7 @@ exports[`gux-form-field-time-picker #render intervals should render component as
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -208,7 +208,7 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -253,7 +253,7 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -298,7 +298,7 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -343,7 +343,7 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           </div>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-time-zone-picker/tests/__snapshots__/gux-form-field-time-zone-picker.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-time-zone-picker/tests/__snapshots__/gux-form-field-time-zone-picker.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`gux-form-field-time-zone-picker #render error should render component a
           <slot></slot>
         </div>
         <div class="gux-form-field-error gux-show">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -77,7 +77,7 @@ exports[`gux-form-field-time-zone-picker #render help should render component as
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -121,7 +121,7 @@ exports[`gux-form-field-time-zone-picker #render input attributes should render 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -159,7 +159,7 @@ exports[`gux-form-field-time-zone-picker #render input attributes should render 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -197,7 +197,7 @@ exports[`gux-form-field-time-zone-picker #render input attributes should render 
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -237,7 +237,7 @@ exports[`gux-form-field-time-zone-picker #render label-position should render co
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -280,7 +280,7 @@ exports[`gux-form-field-time-zone-picker #render label-position should render co
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -323,7 +323,7 @@ exports[`gux-form-field-time-zone-picker #render label-position should render co
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>
@@ -366,7 +366,7 @@ exports[`gux-form-field-time-zone-picker #render label-position should render co
           <slot></slot>
         </div>
         <div class="gux-form-field-error">
-          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-regular"></gux-icon>
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
           </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.scss
@@ -4,6 +4,7 @@
     display: none;
     flex-direction: row;
     flex-wrap: nowrap;
+    gap: var(--gse-ui-formControl-helper-gap);
     place-content: stretch flex-start;
     align-items: center;
     padding: var(--gse-ui-formControl-helper-errorPadding);
@@ -18,11 +19,10 @@
 
     gux-icon {
       flex: 0 1 auto;
-      align-self: auto;
+      align-self: start;
       order: 0;
       min-width: var(--gse-ui-icon-size-sm);
       min-height: var(--gse-ui-icon-size-sm);
-      margin-right: var(--gse-ui-formControl-helper-gap);
       color: var(--gse-ui-formControl-helper-errorColor);
     }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.tsx
@@ -15,10 +15,7 @@ export const GuxFormFieldError: FunctionalComponent<GuxFormFieldErrorProps> = (
         'gux-show': show
       }}
     >
-      <gux-icon
-        icon-name="fa/hexagon-exclamation-regular"
-        decorative
-      ></gux-icon>
+      <gux-icon icon-name="fa/hexagon-exclamation-solid" decorative></gux-icon>
       <div class="gux-message">{children}</div>
     </div>
   ) as VNode;


### PR DESCRIPTION
-Error message icon change
-Error message icon and text container gap change
-Error message icon and text container alignment when text is multi-line - error icon now is positioned at the top of the container instead of the middle. To test this you can add multi-line text in the example page for a component like form-field-checkbox like in the screenshot below:
<img width="1225" alt="Screen Shot 2024-06-06 at 12 47 49 PM" src="https://github.com/MyPureCloud/genesys-spark/assets/127438502/678a81ac-ec9c-4aee-b1e2-d31f6272504a">


✅ Closes: COMUI-2766