### PR TITLE
chore(calendar): Added date placeholder locale tests (WIP)

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.service.ts
@@ -62,3 +62,33 @@ export function getDateMonthAndYearString(date: Date, locale: string) {
     );
   }
 }
+
+const getDatePatternForPart = (part: Intl.DateTimeFormatPart) => {
+  switch (part.type) {
+    case 'day':
+      return 'd'.repeat(part.value.length);
+    case 'month':
+      return 'm'.repeat(part.value.length);
+    case 'year':
+      return 'y'.repeat(part.value.length);
+    case 'literal':
+      return part.value;
+    default:
+      console.log('Unsupported date part', part);
+      return '';
+  }
+};
+
+/**
+ * Get the date format pattern for the given locale.
+ * @example
+ *     getDatePlaceholderForLocale(date, 'en-AU');   // dd/mm/yyyy
+ *     getDatePlaceholderForLocale(date, 'en-US');   // m/d/yyyy
+ */
+export function getDatePlaceholderForLocale(date: Date, locale: string) {
+  // const locale = (new Intl.NumberFormat()).resolvedOptions().locale;
+  return new Intl.DateTimeFormat(locale)
+    .formatToParts(date)
+    .map(getDatePatternForPart)
+    .join('');
+}

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/tests/gux-calendar.service.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/tests/gux-calendar.service.spec.ts
@@ -2,7 +2,8 @@ import {
   firstDateInMonth,
   getWeekdays,
   getOffsetMonthDate,
-  getDateMonthAndYearString
+  getDateMonthAndYearString,
+  getDatePlaceholderForLocale
 } from '../gux-calendar.service';
 
 describe('calendar.service', () => {
@@ -168,6 +169,49 @@ describe('calendar.service', () => {
       it(`should work as expected for ${locale}`, () => {
         expect(
           getDateMonthAndYearString(new Date(2022, 11, 31), locale)
+        ).toEqual(expectedOutput);
+      });
+    });
+  });
+
+  describe('getDatePlaceholderForLocale', () => {
+    [
+      // list of date formats by locale:
+      // https://help.talend.com/en-US/data-preparation-user-guide/7.3/list-of-date-and-date-time-formats
+      // https://docs.oracle.com/cd/E19455-01/806-0169/overview-7/index.html
+      //
+      // List of locale countries:
+      // https://saimana.com/list-of-country-locale-code/
+      { locale: 'ar', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'cs', expectedOutput: 'dd. mm. yyyy' },
+      { locale: 'da', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'de', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'en', expectedOutput: 'mm/dd/yyyy' },
+      { locale: 'es', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'es-es', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'fi', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'fr', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'fr-ca', expectedOutput: 'yyyy-mm-dd' },
+      { locale: 'he', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'it', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'ja', expectedOutput: 'yyyy/mm/dd' },
+      { locale: 'ko', expectedOutput: 'yyyy. mm. dd.' },
+      { locale: 'nl', expectedOutput: 'dd-mm-yyyy' },
+      { locale: 'no', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'pl', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'pt-br', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'pt-pt', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'ru', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'sv', expectedOutput: 'yyyy-mm-dd' },
+      { locale: 'th', expectedOutput: 'dd/mm/yyyy' },
+      { locale: 'tr', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'uk', expectedOutput: 'dd.mm.yyyy' },
+      { locale: 'zh-cn', expectedOutput: 'yyyy-mm-dd' },
+      { locale: 'zh-tw', expectedOutput: 'yyyy-mm-dd' }
+    ].forEach(({ locale, expectedOutput }) => {
+      it(`should work as expected for ${locale}`, () => {
+        expect(
+          getDatePlaceholderForLocale(new Date(2022, 11, 31), locale)
         ).toEqual(expectedOutput);
       });
     });


### PR DESCRIPTION
✅ Closes: COMUI-1348

So far I found that the code in this PR returns the expected placeholders for all locales except these:

-he
-zh-cn
-zh-tw

<img width="1027" alt="Screen Shot 2024-06-10 at 2 15 13 PM" src="https://github.com/MyPureCloud/genesys-spark/assets/127438502/201cd596-ffc2-45da-bd43-613834dde55d">
