### PR TITLE
fix(calendar): addition of fixed height to calendar

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.scss
@@ -118,6 +118,7 @@
   .gux-content {
     display: flex;
     align-items: flex-start;
+    height: var(--gse-ui-calendarMenu-height);
     padding: var(--gse-ui-calendarMenu-dateBody-padding);
     color: var(--gse-ui-calendarMenu-month-default-foregroundColor);
     background-color: var(--gse-ui-calendarMenu-backgroundColor);


### PR DESCRIPTION
**Notes**

Some months in the calendar will cause the calendar height to change when clicking the forward or back buttons which can cause the popover to close easily. Some months that you can see this on are  June, March, September, December for example. They have an extra row causing the height of the calendar to be bigger.

See video here :  https://inindca.atlassian.net/browse/COMUI-2915

To be **backported**

✅ Closes: COMUI-2915