### PR TITLE
feat(pagination-cursor): allowing reference to controlled element

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
@@ -3,7 +3,6 @@
 <div lang="en">
   <div id="default" class="table-placeholder"></div>
   <gux-pagination-cursor
-    controls="default"
     label="Pagination for default example"
   ></gux-pagination-cursor>
 </div>
@@ -13,7 +12,6 @@
   <div id="next" class="table-placeholder"></div>
   <gux-pagination-cursor
     has-next
-    controls="next"
     label="Pagination for next example"
   ></gux-pagination-cursor>
 </div>
@@ -24,7 +22,6 @@
   <gux-pagination-cursor
     has-previous
     has-next
-    controls="next-previous"
     label="Pagination for next and previous example"
   ></gux-pagination-cursor>
 </div>
@@ -34,7 +31,6 @@
   <div id="previous" class="table-placeholder"></div>
   <gux-pagination-cursor
     has-previous
-    controls="previous"
     label="Pagination for previous example"
   ></gux-pagination-cursor>
 </div>
@@ -46,7 +42,6 @@
     layout="advanced"
     has-previous
     has-next
-    controls="advanced"
     label="Pagination for advanced example"
   ></gux-pagination-cursor>
 </div>
@@ -59,7 +54,6 @@
     items-per-page="25"
     has-previous
     has-next
-    controls="advanced-per-item"
     label="Pagination for advanced example with item per page dropdown"
   ></gux-pagination-cursor>
 </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
@@ -1,7 +1,7 @@
 <h1>gux-pagination-cursor</h1>
 <h2>Default (no previous or next page available)</h2>
 <div lang="en">
-  <div id="default" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     label="Pagination for default example"
   ></gux-pagination-cursor>
@@ -9,7 +9,7 @@
 
 <h2>Next page available</h2>
 <div lang="en">
-  <div id="next" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     has-next
     label="Pagination for next example"
@@ -18,7 +18,7 @@
 
 <h2>Next and previous page available</h2>
 <div lang="en">
-  <div id="next-previous" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     has-previous
     has-next
@@ -28,7 +28,7 @@
 
 <h2>Previous page available</h2>
 <div lang="en">
-  <div id="previous" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     has-previous
     label="Pagination for previous example"
@@ -37,7 +37,7 @@
 
 <h2>Advanced Layout</h2>
 <div lang="en">
-  <div id="advanced" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     layout="advanced"
     has-previous
@@ -48,7 +48,7 @@
 
 <h2>Advanced Layout with Item Per Page dropdown</h2>
 <div lang="en">
-  <div id="advanced-per-item" class="table-placeholder"></div>
+  <div class="table-placeholder"></div>
   <gux-pagination-cursor
     layout="advanced"
     items-per-page="25"

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/example.html
@@ -1,46 +1,66 @@
 <h1>gux-pagination-cursor</h1>
 <h2>Default (no previous or next page available)</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
-  <gux-pagination-cursor></gux-pagination-cursor>
+  <div id="default" class="table-placeholder"></div>
+  <gux-pagination-cursor
+    controls="default"
+    label="Pagination for default example"
+  ></gux-pagination-cursor>
 </div>
 
 <h2>Next page available</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
-  <gux-pagination-cursor has-next></gux-pagination-cursor>
+  <div id="next" class="table-placeholder"></div>
+  <gux-pagination-cursor
+    has-next
+    controls="next"
+    label="Pagination for next example"
+  ></gux-pagination-cursor>
 </div>
 
 <h2>Next and previous page available</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
-  <gux-pagination-cursor has-previous has-next></gux-pagination-cursor>
+  <div id="next-previous" class="table-placeholder"></div>
+  <gux-pagination-cursor
+    has-previous
+    has-next
+    controls="next-previous"
+    label="Pagination for next and previous example"
+  ></gux-pagination-cursor>
 </div>
 
 <h2>Previous page available</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
-  <gux-pagination-cursor has-previous></gux-pagination-cursor>
+  <div id="previous" class="table-placeholder"></div>
+  <gux-pagination-cursor
+    has-previous
+    controls="previous"
+    label="Pagination for previous example"
+  ></gux-pagination-cursor>
 </div>
 
 <h2>Advanced Layout</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
+  <div id="advanced" class="table-placeholder"></div>
   <gux-pagination-cursor
     layout="advanced"
     has-previous
     has-next
+    controls="advanced"
+    label="Pagination for advanced example"
   ></gux-pagination-cursor>
 </div>
 
 <h2>Advanced Layout with Item Per Page dropdown</h2>
 <div lang="en">
-  <div class="table-placeholder"></div>
+  <div id="advanced-per-item" class="table-placeholder"></div>
   <gux-pagination-cursor
     layout="advanced"
     items-per-page="25"
     has-previous
     has-next
+    controls="advanced-per-item"
+    label="Pagination for advanced example with item per page dropdown"
   ></gux-pagination-cursor>
 </div>
 

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
@@ -10,7 +10,6 @@ import {
 
 import { trackComponent } from '@utils/tracking/usage';
 import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
-import { logWarn } from '@utils/error/log-error';
 
 import translationResources from './i18n/en.json';
 import { GuxPaginationCursorDetail } from './gux-pagination-cursor.types';
@@ -46,12 +45,6 @@ export class GuxPaginationCursor {
   @Prop()
   layout: 'simple' | 'advanced' = 'simple';
 
-  /**
-   * ID of the element that contains the paginated content to aid accessibility.
-   */
-  @Prop()
-  controls: string;
-
   @Event()
   private guxPaginationCursorchange: EventEmitter<GuxPaginationCursorDetail>;
 
@@ -74,10 +67,6 @@ export class GuxPaginationCursor {
   async componentWillLoad(): Promise<void> {
     trackComponent(this.root);
 
-    if (!this.controls) {
-      logWarn(this.root, 'A controls prop may help with accessibility');
-    }
-
     this.i18n = await buildI18nForComponent(this.root, translationResources);
   }
 
@@ -90,7 +79,6 @@ export class GuxPaginationCursor {
             type="button"
             disabled={!this.hasPrevious}
             onClick={() => this.onButtonClick('previous')}
-            aria-controls={this.controls}
           >
             <gux-icon
               iconName="custom/chevron-left-small-regular"
@@ -104,7 +92,6 @@ export class GuxPaginationCursor {
             type="button"
             disabled={!this.hasNext}
             onClick={() => this.onButtonClick('next')}
-            aria-controls={this.controls}
           >
             <gux-icon
               iconName="custom/chevron-right-small-regular"

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/gux-pagination-cursor.tsx
@@ -10,6 +10,7 @@ import {
 
 import { trackComponent } from '@utils/tracking/usage';
 import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
+import { logWarn } from '@utils/error/log-error';
 
 import translationResources from './i18n/en.json';
 import { GuxPaginationCursorDetail } from './gux-pagination-cursor.types';
@@ -33,6 +34,9 @@ export class GuxPaginationCursor {
   @Prop()
   hasNext: boolean = false;
 
+  @Prop()
+  label: string;
+
   /**
    * Optional. Shows items per page dropdown when set. Only available with layout set to 'advanced'
    */
@@ -41,6 +45,12 @@ export class GuxPaginationCursor {
 
   @Prop()
   layout: 'simple' | 'advanced' = 'simple';
+
+  /**
+   * ID of the element that contains the paginated content to aid accessibility.
+   */
+  @Prop()
+  controls: string;
 
   @Event()
   private guxPaginationCursorchange: EventEmitter<GuxPaginationCursorDetail>;
@@ -64,18 +74,23 @@ export class GuxPaginationCursor {
   async componentWillLoad(): Promise<void> {
     trackComponent(this.root);
 
+    if (!this.controls) {
+      logWarn(this.root, 'A controls prop may help with accessibility');
+    }
+
     this.i18n = await buildI18nForComponent(this.root, translationResources);
   }
 
   renderSimpleLayout(): JSX.Element {
     return [
-      <div role="navigation" class="gux-pagination-button-container">
+      <nav aria-label={this.label} class="gux-pagination-button-container">
         <gux-button-slot accent="ghost">
           <button
             class="gux-simple-button"
             type="button"
             disabled={!this.hasPrevious}
             onClick={() => this.onButtonClick('previous')}
+            aria-controls={this.controls}
           >
             <gux-icon
               iconName="custom/chevron-left-small-regular"
@@ -89,6 +104,7 @@ export class GuxPaginationCursor {
             type="button"
             disabled={!this.hasNext}
             onClick={() => this.onButtonClick('next')}
+            aria-controls={this.controls}
           >
             <gux-icon
               iconName="custom/chevron-right-small-regular"
@@ -96,13 +112,13 @@ export class GuxPaginationCursor {
             ></gux-icon>
           </button>
         </gux-button-slot>
-      </div>
+      </nav>
     ] as JSX.Element;
   }
 
   renderAdvancedLayout(): JSX.Element {
     return [
-      <div role="navigation" class="gux-pagination-button-container">
+      <nav aria-label={this.label} class="gux-pagination-button-container">
         <gux-button-slot accent="ghost">
           <button
             type="button"
@@ -133,7 +149,7 @@ export class GuxPaginationCursor {
             </div>
           </button>
         </gux-button-slot>
-      </div>,
+      </nav>,
       this.renderItemsPerPage()
     ] as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/readme.md
@@ -9,10 +9,10 @@
 
 | Property       | Attribute        | Description                                                                                    | Type                     | Default     |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------- | ------------------------ | ----------- |
-| `controls`     | `controls`       | ID of the element that contains the paginated content to aid accessibility.                    | `string`                 | `undefined` |
 | `hasNext`      | `has-next`       |                                                                                                | `boolean`                | `false`     |
 | `hasPrevious`  | `has-previous`   |                                                                                                | `boolean`                | `false`     |
 | `itemsPerPage` | `items-per-page` | Optional. Shows items per page dropdown when set. Only available with layout set to 'advanced' | `100 \| 25 \| 50 \| 75`  | `undefined` |
+| `label`        | `label`          |                                                                                                | `string`                 | `undefined` |
 | `layout`       | `layout`         |                                                                                                | `"advanced" \| "simple"` | `'simple'`  |
 
 

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/readme.md
@@ -9,6 +9,7 @@
 
 | Property       | Attribute        | Description                                                                                    | Type                     | Default     |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------- | ------------------------ | ----------- |
+| `controls`     | `controls`       | ID of the element that contains the paginated content to aid accessibility.                    | `string`                 | `undefined` |
 | `hasNext`      | `has-next`       |                                                                                                | `boolean`                | `false`     |
 | `hasPrevious`  | `has-previous`   |                                                                                                | `boolean`                | `false`     |
 | `itemsPerPage` | `items-per-page` | Optional. Shows items per page dropdown when set. Only available with layout set to 'advanced' | `100 \| 25 \| 50 \| 75`  | `undefined` |

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.e2e.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.e2e.ts.snap
@@ -8,4 +8,4 @@ exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `"<gu
 
 exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `"<gux-pagination-cursor lang="en" has-previous="" hydrated=""></gux-pagination-cursor>"`;
 
-exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `"<gux-pagination-cursor lang="en" layout="advanced" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `"<gux-pagination-cursor lang="en" layout="advanced" controls="id5" label="Example label" hydrated=""></gux-pagination-cursor>"`;

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.e2e.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.e2e.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gux-pagination-cursor #render should render as expected (1) 1`] = `"<gux-pagination-cursor lang="en" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (1) 1`] = `"<gux-pagination-cursor lang="en" label="Example label" hydrated=""></gux-pagination-cursor>"`;
 
-exports[`gux-pagination-cursor #render should render as expected (2) 1`] = `"<gux-pagination-cursor lang="en" has-next="" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (2) 1`] = `"<gux-pagination-cursor lang="en" has-next="" label="Example label" hydrated=""></gux-pagination-cursor>"`;
 
-exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `"<gux-pagination-cursor lang="en" has-previous="" has-next="" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `"<gux-pagination-cursor lang="en" has-previous="" has-next="" label="Example label" hydrated=""></gux-pagination-cursor>"`;
 
-exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `"<gux-pagination-cursor lang="en" has-previous="" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `"<gux-pagination-cursor lang="en" has-previous="" label="Example label" hydrated=""></gux-pagination-cursor>"`;
 
-exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `"<gux-pagination-cursor lang="en" layout="advanced" controls="id5" label="Example label" hydrated=""></gux-pagination-cursor>"`;
+exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `"<gux-pagination-cursor lang="en" layout="advanced" label="Example label" hydrated=""></gux-pagination-cursor>"`;

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.spec.ts.snap
@@ -1,85 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gux-pagination-cursor #render should render as expected (1) 1`] = `
-<gux-pagination-cursor>
+<gux-pagination-cursor controls="id1" label="Example label">
   <mock:shadow-root>
-    <div class="gux-pagination-button-container" role="navigation">
+    <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" disabled="" type="button">
+        <button aria-controls="id1" class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" disabled="" type="button">
+        <button aria-controls="id1" class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
-    </div>
+    </nav>
   </mock:shadow-root>
 </gux-pagination-cursor>
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (2) 1`] = `
-<gux-pagination-cursor has-next="">
+<gux-pagination-cursor controls="id2" has-next="" label="Example label">
   <mock:shadow-root>
-    <div class="gux-pagination-button-container" role="navigation">
+    <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" disabled="" type="button">
+        <button aria-controls="id2" class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" type="button">
+        <button aria-controls="id2" class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
-    </div>
+    </nav>
   </mock:shadow-root>
 </gux-pagination-cursor>
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `
-<gux-pagination-cursor has-next="" has-previous="">
+<gux-pagination-cursor controls="id3" has-next="" has-previous="" label="Example label">
   <mock:shadow-root>
-    <div class="gux-pagination-button-container" role="navigation">
+    <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" type="button">
+        <button aria-controls="id3" class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" type="button">
+        <button aria-controls="id3" class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
-    </div>
+    </nav>
   </mock:shadow-root>
 </gux-pagination-cursor>
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `
-<gux-pagination-cursor has-previous="">
+<gux-pagination-cursor controls="id4" has-previous="" label="Example label">
   <mock:shadow-root>
-    <div class="gux-pagination-button-container" role="navigation">
+    <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" type="button">
+        <button aria-controls="id4" class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button class="gux-simple-button" disabled="" type="button">
+        <button aria-controls="id4" class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
-    </div>
+    </nav>
   </mock:shadow-root>
 </gux-pagination-cursor>
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `
-<gux-pagination-cursor layout="advanced">
+<gux-pagination-cursor controls="id5" label="Example label" layout="advanced">
   <mock:shadow-root>
-    <div class="gux-pagination-button-container" role="navigation">
+    <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
         <button disabled="" type="button">
           <div class="gux-button-align-content">
@@ -100,7 +100,7 @@ exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `
           </div>
         </button>
       </gux-button-slot>
-    </div>
+    </nav>
   </mock:shadow-root>
 </gux-pagination-cursor>
 `;

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/__snapshots__/gux-pagination-cursor.spec.ts.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gux-pagination-cursor #render should render as expected (1) 1`] = `
-<gux-pagination-cursor controls="id1" label="Example label">
+<gux-pagination-cursor label="Example label">
   <mock:shadow-root>
     <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button aria-controls="id1" class="gux-simple-button" disabled="" type="button">
+        <button class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button aria-controls="id1" class="gux-simple-button" disabled="" type="button">
+        <button class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
@@ -20,16 +20,16 @@ exports[`gux-pagination-cursor #render should render as expected (1) 1`] = `
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (2) 1`] = `
-<gux-pagination-cursor controls="id2" has-next="" label="Example label">
+<gux-pagination-cursor has-next="" label="Example label">
   <mock:shadow-root>
     <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button aria-controls="id2" class="gux-simple-button" disabled="" type="button">
+        <button class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button aria-controls="id2" class="gux-simple-button" type="button">
+        <button class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
@@ -39,16 +39,16 @@ exports[`gux-pagination-cursor #render should render as expected (2) 1`] = `
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `
-<gux-pagination-cursor controls="id3" has-next="" has-previous="" label="Example label">
+<gux-pagination-cursor has-next="" has-previous="" label="Example label">
   <mock:shadow-root>
     <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button aria-controls="id3" class="gux-simple-button" type="button">
+        <button class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button aria-controls="id3" class="gux-simple-button" type="button">
+        <button class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
@@ -58,16 +58,16 @@ exports[`gux-pagination-cursor #render should render as expected (3) 1`] = `
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `
-<gux-pagination-cursor controls="id4" has-previous="" label="Example label">
+<gux-pagination-cursor has-previous="" label="Example label">
   <mock:shadow-root>
     <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">
-        <button aria-controls="id4" class="gux-simple-button" type="button">
+        <button class="gux-simple-button" type="button">
           <gux-icon iconname="custom/chevron-left-small-regular" screenreader-text="Previous"></gux-icon>
         </button>
       </gux-button-slot>
       <gux-button-slot accent="ghost">
-        <button aria-controls="id4" class="gux-simple-button" disabled="" type="button">
+        <button class="gux-simple-button" disabled="" type="button">
           <gux-icon iconname="custom/chevron-right-small-regular" screenreader-text="Next"></gux-icon>
         </button>
       </gux-button-slot>
@@ -77,7 +77,7 @@ exports[`gux-pagination-cursor #render should render as expected (4) 1`] = `
 `;
 
 exports[`gux-pagination-cursor #render should render as expected (5) 1`] = `
-<gux-pagination-cursor controls="id5" label="Example label" layout="advanced">
+<gux-pagination-cursor label="Example label" layout="advanced">
   <mock:shadow-root>
     <nav aria-label="Example label" class="gux-pagination-button-container">
       <gux-button-slot accent="ghost">

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.e2e.ts
@@ -19,11 +19,11 @@ async function clickButton(page: E2EPage, buttonToClick: 'previous' | 'next') {
 describe('gux-pagination-cursor', () => {
   describe('#render', () => {
     [
-      '<gux-pagination-cursor lang="en"></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-next></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-previous has-next></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-previous></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" layout="advanced"></gux-pagination-cursor>'
+      '<gux-pagination-cursor lang="en" controls="id1" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-next controls="id2" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-previous has-next controls="id3" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-previous controls="id4" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" layout="advanced" controls="id5" label="Example label"></gux-pagination-cursor>'
     ].forEach((html, index) => {
       it(`should render as expected (${index + 1})`, async () => {
         const page = await newSparkE2EPage({ html });
@@ -38,7 +38,7 @@ describe('gux-pagination-cursor', () => {
   describe('guxPaginationCursorchange', () => {
     it('should fire guxPaginationCursorchange(previous) event when enabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" has-previous></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" has-previous controls="previous" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -54,7 +54,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should fire guxPaginationCursorchange(next) event when enabled next button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" has-next></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" has-next controls="next" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -67,7 +67,8 @@ describe('gux-pagination-cursor', () => {
     });
 
     it('should not fire guxPaginationCursorchange(previous) event when disabled previous button is clicked', async () => {
-      const html = '<gux-pagination-cursor lang="en"></gux-pagination-cursor>';
+      const html =
+        '<gux-pagination-cursor lang="en" controls="previous-disabled" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -81,7 +82,8 @@ describe('gux-pagination-cursor', () => {
     });
 
     it('should not fire guxPaginationCursorchange(next) event when disabled next button is clicked', async () => {
-      const html = '<gux-pagination-cursor lang="en"></gux-pagination-cursor>';
+      const html =
+        '<gux-pagination-cursor lang="en" controls="next-disabled" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.e2e.ts
@@ -19,11 +19,11 @@ async function clickButton(page: E2EPage, buttonToClick: 'previous' | 'next') {
 describe('gux-pagination-cursor', () => {
   describe('#render', () => {
     [
-      '<gux-pagination-cursor lang="en" controls="id1" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-next controls="id2" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-previous has-next controls="id3" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" has-previous controls="id4" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor lang="en" layout="advanced" controls="id5" label="Example label"></gux-pagination-cursor>'
+      '<gux-pagination-cursor lang="en" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-next label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-previous has-next label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" has-previous label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor lang="en" layout="advanced" label="Example label"></gux-pagination-cursor>'
     ].forEach((html, index) => {
       it(`should render as expected (${index + 1})`, async () => {
         const page = await newSparkE2EPage({ html });
@@ -38,7 +38,7 @@ describe('gux-pagination-cursor', () => {
   describe('guxPaginationCursorchange', () => {
     it('should fire guxPaginationCursorchange(previous) event when enabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" has-previous controls="previous" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" has-previous label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -54,7 +54,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should fire guxPaginationCursorchange(next) event when enabled next button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" has-next controls="next" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" has-next label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -68,7 +68,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should not fire guxPaginationCursorchange(previous) event when disabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" controls="previous-disabled" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'
@@ -83,7 +83,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should not fire guxPaginationCursorchange(next) event when disabled next button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor lang="en" controls="next-disabled" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor lang="en" label="Example label"></gux-pagination-cursor>';
       const page = await newSparkE2EPage({ html });
       const guxPaginationCursorchangeSpy = await page.spyOnEvent(
         'guxPaginationCursorchange'

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.spec.ts
@@ -7,11 +7,11 @@ const language = 'en';
 describe('gux-pagination-cursor', () => {
   describe('#render', () => {
     [
-      '<gux-pagination-cursor controls="id1" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-next controls="id2" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-previous has-next controls="id3" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-previous controls="id4" label="Example label"></gux-pagination-cursor>',
-      '<gux-pagination-cursor layout="advanced" controls="id5" label="Example label"></gux-pagination-cursor>'
+      '<gux-pagination-cursor label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-next label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-previous has-next label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-previous label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor layout="advanced" label="Example label"></gux-pagination-cursor>'
     ].forEach((html, index) => {
       it(`should render as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });
@@ -25,7 +25,7 @@ describe('gux-pagination-cursor', () => {
   describe('guxPaginationCursorchange', () => {
     it('should fire guxPaginationCursorchange(previous) event when enabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor has-previous controls="previous" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor has-previous label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [previousButton] = Array.from(
@@ -48,7 +48,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should fire guxPaginationCursorchange(next) event when enabled next button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor has-next controls="next" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor has-next label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [, nextButton] = Array.from(
@@ -71,7 +71,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should not fire guxPaginationCursorchange(previous) event when disabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor controls="previous-disabled" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [previousButton] = Array.from(
@@ -92,7 +92,7 @@ describe('gux-pagination-cursor', () => {
 
     it('should not fire guxPaginationCursorchange(next) event when disabled next button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor controls="next-disabled" label="Example label"></gux-pagination-cursor>';
+        '<gux-pagination-cursor label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [, nextButton] = Array.from(

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination-cursor/tests/gux-pagination-cursor.spec.ts
@@ -7,11 +7,11 @@ const language = 'en';
 describe('gux-pagination-cursor', () => {
   describe('#render', () => {
     [
-      '<gux-pagination-cursor></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-next></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-previous has-next></gux-pagination-cursor>',
-      '<gux-pagination-cursor has-previous></gux-pagination-cursor>',
-      '<gux-pagination-cursor layout="advanced"></gux-pagination-cursor>'
+      '<gux-pagination-cursor controls="id1" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-next controls="id2" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-previous has-next controls="id3" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor has-previous controls="id4" label="Example label"></gux-pagination-cursor>',
+      '<gux-pagination-cursor layout="advanced" controls="id5" label="Example label"></gux-pagination-cursor>'
     ].forEach((html, index) => {
       it(`should render as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });
@@ -25,7 +25,7 @@ describe('gux-pagination-cursor', () => {
   describe('guxPaginationCursorchange', () => {
     it('should fire guxPaginationCursorchange(previous) event when enabled previous button is clicked', async () => {
       const html =
-        '<gux-pagination-cursor has-previous></gux-pagination-cursor>';
+        '<gux-pagination-cursor has-previous controls="previous" label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [previousButton] = Array.from(
@@ -47,7 +47,8 @@ describe('gux-pagination-cursor', () => {
     });
 
     it('should fire guxPaginationCursorchange(next) event when enabled next button is clicked', async () => {
-      const html = '<gux-pagination-cursor has-next></gux-pagination-cursor>';
+      const html =
+        '<gux-pagination-cursor has-next controls="next" label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [, nextButton] = Array.from(
@@ -69,7 +70,8 @@ describe('gux-pagination-cursor', () => {
     });
 
     it('should not fire guxPaginationCursorchange(previous) event when disabled previous button is clicked', async () => {
-      const html = '<gux-pagination-cursor></gux-pagination-cursor>';
+      const html =
+        '<gux-pagination-cursor controls="previous-disabled" label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [previousButton] = Array.from(
@@ -89,7 +91,8 @@ describe('gux-pagination-cursor', () => {
     });
 
     it('should not fire guxPaginationCursorchange(next) event when disabled next button is clicked', async () => {
-      const html = '<gux-pagination-cursor></gux-pagination-cursor>';
+      const html =
+        '<gux-pagination-cursor controls="next-disabled" label="Example label"></gux-pagination-cursor>';
       const page = await newSpecPage({ components, html, language });
       const element = page.root as HTMLElement;
       const [, nextButton] = Array.from(


### PR DESCRIPTION
New 'controls' prop to pass an ID of the 'controlled' element to the buttons to establish a reference.
Throwing a warning if the prop not present.

Aria-controls "Identifies the element (or elements) whose contents or presence are controlled by the current element."
https://w3c.github.io/aria/#aria-controls

Some screenreaders allow the virtual cursor to return its focus to the controlled element.
