### PR TITLE
fix(popover): Clicking an element within the popover does not close the popover

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -92,9 +92,8 @@ export class GuxPopover {
       return;
     }
 
-    const focusIsOutsidePopover = !this.root.contains(
-      event.relatedTarget as Node
-    );
+    const focusIsOutsidePopover =
+      event.relatedTarget && !this.root.contains(event.relatedTarget as Node);
     if (focusIsOutsidePopover) {
       this.dismiss();
     }

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -94,6 +94,7 @@ export class GuxPopover {
 
     const focusIsOutsidePopover =
       event.relatedTarget && !this.root.contains(event.relatedTarget as Node);
+
     if (focusIsOutsidePopover) {
       this.dismiss();
     }

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -94,7 +94,6 @@ export class GuxPopover {
 
     const focusIsOutsidePopover =
       event.relatedTarget && !this.root.contains(event.relatedTarget as Node);
-
     if (focusIsOutsidePopover) {
       this.dismiss();
     }


### PR DESCRIPTION
There was an issue when clicking an element within the popover after focus is on another element within the popover was triggering the focus out event and closing the popover, which wasn't expected behavior. This PR fixes this issue.

✅ Closes: COMUI-1471