### PR TITLE
docs(icon): splitting icons into multiple pages

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/current.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/current.html
@@ -2,7 +2,10 @@
 
 <nav>
   <ul>
-    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon.html">Usage Guidelines</a></li>
+    <li>
+      <a href="gux-icon-current.html" aria-current="page">Current icons</a>
+    </li>
     <li><a href="gux-icon-spark.html">Spark icons</a></li>
     <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
     <li><a href="gux-icon-legacy.html">Legacy icons</a></li>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/current.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/current.html
@@ -1,0 +1,50 @@
+<h1>gux-icon</h1>
+
+<nav>
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
+
+<h2>Font Awesome Icons</h2>
+<p>
+  <a
+    href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
+    target="_blank"
+    >Request new FontAwesome icons</a
+  >
+</p>
+${FA_ICON_EXAMPLE_LIST}
+
+<h2>Custom Icons</h2>
+<p>
+  <a
+    href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
+    target="_blank"
+    >Request new custom icons</a
+  >
+</p>
+${CUSTOM_ICON_EXAMPLE_LIST}
+
+<style>
+  gux-icon {
+    color: var(--gse-core-color-cornflower-700);
+  }
+
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    width: 100%;
+  }
+
+  .icon-example {
+    width: 200px;
+    height: 100px;
+    text-align: center;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/deprecated.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/deprecated.html
@@ -1,0 +1,36 @@
+<h1>gux-icon</h1>
+
+<nav>
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
+
+<h2>Deprecated</h2>
+
+<p>These icons have been deprecated.</p>
+
+${DEPRECATED_ICON_EXAMPLE_LIST}
+
+<style>
+  gux-icon {
+    color: var(--gse-core-color-cornflower-700);
+  }
+
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    width: 100%;
+  }
+
+  .icon-example {
+    width: 200px;
+    height: 100px;
+    text-align: center;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/deprecated.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/deprecated.html
@@ -2,11 +2,16 @@
 
 <nav>
   <ul>
+    <li><a href="gux-icon.html">Usage Guidelines</a></li>
     <li><a href="gux-icon-current.html">Current icons</a></li>
     <li><a href="gux-icon-spark.html">Spark icons</a></li>
     <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
     <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
-    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+    <li>
+      <a href="gux-icon-deprecated.html" aria-current="page"
+        >Deprecated icons</a
+      >
+    </li>
   </ul>
 </nav>
 

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/legacy.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/legacy.html
@@ -2,10 +2,11 @@
 
 <nav>
   <ul>
+    <li><a href="gux-icon.html">Usage Guidelines</a></li>
     <li><a href="gux-icon-current.html">Current icons</a></li>
     <li><a href="gux-icon-spark.html">Spark icons</a></li>
     <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
-    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-legacy.html" aria-current="page">Legacy icons</a></li>
     <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
   </ul>
 </nav>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/legacy.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/legacy.html
@@ -1,0 +1,45 @@
+<h1>gux-icon</h1>
+
+<nav>
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
+
+<h2>Legacy Icons</h2>
+
+<gux-icon size="large" icon-name="legacy/cc-delivery" decorative></gux-icon>
+<p>
+  After a review of icons in this project many of them were removed as they will
+  not be part of the official Spark Design System. You should migrate all usage
+  of these icons where possible and if not possible contact the Spark Design
+  System team to get a suitable icon added to the system. For convenience all
+  legacy icons will be available via a "legacy/" prefix to aid in the transition
+  to officially supported icons.
+</p>
+
+<h2>Legacy Icons (Migrate away from these)</h2>
+${LEGACY_ICON_EXAMPLE_LIST}
+
+<style>
+  gux-icon {
+    color: var(--gse-core-color-cornflower-700);
+  }
+
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    width: 100%;
+  }
+
+  .icon-example {
+    width: 200px;
+    height: 100px;
+    text-align: center;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/restricted.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/restricted.html
@@ -2,9 +2,14 @@
 
 <nav>
   <ul>
+    <li><a href="gux-icon.html">Usage Guidelines</a></li>
     <li><a href="gux-icon-current.html">Current icons</a></li>
     <li><a href="gux-icon-spark.html">Spark icons</a></li>
-    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li>
+      <a href="gux-icon-restricted.html" aria-current="page"
+        >Restricted icons</a
+      >
+    </li>
     <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
     <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
   </ul>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/restricted.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/restricted.html
@@ -1,0 +1,45 @@
+<h1>gux-icon</h1>
+
+<nav>
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
+
+<h2>Restricted Icons</h2>
+
+<p>
+  These icons have carefully defined uses and require approval from the Spark
+  team to apply.
+  <a
+    href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
+    target="_blank"
+    >Request the use of a restricted icon</a
+  >
+</p>
+
+<h2>Restricted Icons (Approval required before use)</h2>
+${RESTRICTED_ICON_EXAMPLE_LIST}
+
+<style>
+  gux-icon {
+    color: var(--gse-core-color-cornflower-700);
+  }
+
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    width: 100%;
+  }
+
+  .icon-example {
+    width: 200px;
+    height: 100px;
+    text-align: center;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/spark.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/spark.html
@@ -2,8 +2,9 @@
 
 <nav>
   <ul>
+    <li><a href="gux-icon.html">Usage Guidelines</a></li>
     <li><a href="gux-icon-current.html">Current icons</a></li>
-    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-spark.html" aria-current="page">Spark icons</a></li>
     <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
     <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
     <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/docs/spark.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/docs/spark.html
@@ -1,0 +1,39 @@
+<h1>gux-icon</h1>
+
+<nav>
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
+
+<h2>Spark Icons</h2>
+
+<p>
+  These icon names map to a Font Awesome icon. The latest guidance from UX is to
+  not use these icon names but use the appropriate Font Awesome icon name
+  directly.
+</p>
+${SPARK_ICON_EXAMPLE_LIST}
+
+<style>
+  gux-icon {
+    color: var(--gse-core-color-cornflower-700);
+  }
+
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    width: 100%;
+  }
+
+  .icon-example {
+    width: 200px;
+    height: 100px;
+    text-align: center;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
@@ -1,265 +1,179 @@
 <h1>gux-icon</h1>
 
-<gux-tabs class="example">
-  <gux-tab-list slot="tab-list">
-    <gux-tab tab-id="1-1">Usage</gux-tab>
-    <gux-tab tab-id="1-2">Current icons</gux-tab>
-    <gux-tab tab-id="1-3">Legacy icons</gux-tab>
-    <gux-tab tab-id="1-4">Restricted icons</gux-tab>
-    <gux-tab tab-id="1-5">Deprecated icons</gux-tab>
-  </gux-tab-list>
-  <gux-tab-panel tab-id="1-1">
-    <div>
-      <h2 id="shadow-dom-header">Shadow DOM</h2>
-      <div id="shadow-dom-host"></div>
-      <p>
-        The `gux-icon` is expected to work even when used in the shadow dom
-        (open)
-      </p>
+<nav class="icon-nav">
+  <ul>
+    <li><a href="gux-icon-current.html">Current icons</a></li>
+    <li><a href="gux-icon-spark.html">Spark icons</a></li>
+    <li><a href="gux-icon-restricted.html">Restricted icons</a></li>
+    <li><a href="gux-icon-legacy.html">Legacy icons</a></li>
+    <li><a href="gux-icon-deprecated.html">Deprecated icons</a></li>
+  </ul>
+</nav>
 
-      <h2>Accessibility</h2>
-      <gux-icon size="large" icon-name="bus" decorative></gux-icon>
-      <p>
-        Set the <strong>decorative</strong> attrribute if the icon does not
-        convey information about the page and is only for decoration
-      </p>
+<h2 id="shadow-dom-header">Shadow DOM</h2>
+<div id="shadow-dom-host"></div>
+<p>
+  The `gux-icon` is expected to work even when used in the shadow dom (open)
+</p>
 
-      <gux-icon
-        size="large"
-        icon-name="user-add"
-        screenreader-text="add John Smith to contact list"
-      ></gux-icon>
-      <p>
-        Set the <strong>screenreader-text</strong> attribute if the icon conveys
-        information to the user that would not otherwise be available
-      </p>
+<h2>Accessibility</h2>
+<gux-icon size="large" icon-name="bus" decorative></gux-icon>
+<p>
+  Set the <strong>decorative</strong> attrribute if the icon does not convey
+  information about the page and is only for decoration
+</p>
 
-      <gux-icon size="large" icon-name="fa/bullseye-regular"></gux-icon>
-      <p>
-        If neither <strong>decorative</strong> or
-        <strong>screenreader-text</strong>
-        are set an error will be logged in the console
-      </p>
+<gux-icon
+  size="large"
+  icon-name="user-add"
+  screenreader-text="add John Smith to contact list"
+></gux-icon>
+<p>
+  Set the <strong>screenreader-text</strong> attribute if the icon conveys
+  information to the user that would not otherwise be available
+</p>
 
-      <h2>Styling</h2>
-      <gux-icon
-        size="large"
-        id="styled"
-        icon-name="user-add"
-        decorative
-      ></gux-icon>
-      <p>
-        You can use the <strong>color</strong>, <strong>height</strong> and
-        <strong>width</strong> css properties to style your icon
-      </p>
+<gux-icon size="large" icon-name="fa/bullseye-regular"></gux-icon>
+<p>
+  If neither <strong>decorative</strong> or
+  <strong>screenreader-text</strong>
+  are set an error will be logged in the console
+</p>
 
-      <h2>Sizing</h2>
+<h2>Styling</h2>
+<gux-icon size="large" id="styled" icon-name="user-add" decorative></gux-icon>
+<p>
+  You can use the <strong>color</strong>, <strong>height</strong> and
+  <strong>width</strong> css properties to style your icon
+</p>
 
-      <h3>inherit (height and width set on element)</h3>
-      <gux-icon
-        style="width: 19px; height: 19px"
-        icon-name="user-add"
-        decorative
-      ></gux-icon>
+<h2>Sizing</h2>
 
-      <h3>small (16x16)</h3>
-      <gux-icon size="small" icon-name="user-add" decorative></gux-icon>
+<h3>inherit (height and width set on element)</h3>
+<gux-icon
+  style="width: 19px; height: 19px"
+  icon-name="user-add"
+  decorative
+></gux-icon>
 
-      <h3>medium (24x24)</h3>
-      <gux-icon size="medium" icon-name="user-add" decorative></gux-icon>
+<h3>small (16x16)</h3>
+<gux-icon size="small" icon-name="user-add" decorative></gux-icon>
 
-      <h3>large (32x32)</h3>
-      <gux-icon size="large" icon-name="user-add" decorative></gux-icon>
+<h3>medium (24x24)</h3>
+<gux-icon size="medium" icon-name="user-add" decorative></gux-icon>
 
-      <h2>Caching</h2>
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-left-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-center-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-right-regular"
-          decorative
-        ></gux-icon>
-      </div>
-      <hr />
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-left-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-center-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-right-regular"
-          decorative
-        ></gux-icon>
-      </div>
-      <hr />
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-left-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-center-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-right-regular"
-          decorative
-        ></gux-icon>
-      </div>
-      <hr />
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-left-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-center-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-right-regular"
-          decorative
-        ></gux-icon>
-      </div>
-      <hr />
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-left-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-center-regular"
-          decorative
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="fa/align-right-regular"
-          decorative
-        ></gux-icon>
-      </div>
-      <hr />
-      <div>
-        <gux-icon
-          size="large"
-          icon-name="user"
-          screenreader-text="user-01"
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="user"
-          screenreader-text="user-02"
-        ></gux-icon>
-        <gux-icon
-          size="large"
-          icon-name="user"
-          screenreader-text="user-03"
-        ></gux-icon>
-      </div>
-      <p>Duplicated icons should not require additional network calls</p>
-    </div>
-  </gux-tab-panel>
-  <gux-tab-panel tab-id="1-2">
-    <div>
-      <h2>Font Awesome Icons</h2>
-      <p>
-        <a
-          href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
-          target="_blank"
-          >Request new FontAwesome icons</a
-        >
-      </p>
-      ${FA_ICON_EXAMPLE_LIST}
+<h3>large (32x32)</h3>
+<gux-icon size="large" icon-name="user-add" decorative></gux-icon>
 
-      <h2>Custom Icons</h2>
-      <p>
-        <a
-          href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
-          target="_blank"
-          >Request new custom icons</a
-        >
-      </p>
-      ${CUSTOM_ICON_EXAMPLE_LIST}
-
-      <h2>Spark Icons</h2>
-      <p>
-        These icon names map to a Font Awesome icon. The latest guidance from UX
-        is to not use these icon names but use the appropriate Font Awesome icon
-        name directly.
-      </p>
-      ${SPARK_ICON_EXAMPLE_LIST}
-    </div>
-  </gux-tab-panel>
-  <gux-tab-panel tab-id="1-3">
-    <div>
-      <h2>Legacy</h2>
-      <gux-icon
-        size="large"
-        icon-name="legacy/cc-delivery"
-        decorative
-      ></gux-icon>
-      <p>
-        After a review of icons in this project many of them were removed as
-        they will not be part of the official Spark Design System. You should
-        migrate all usage of these icons where possible and if not possible
-        contact the Spark Design System team to get a suitable icon added to the
-        system. For convenience all legacy icons will be available via a
-        "legacy/" prefix to aid in the transition to officially supported icons.
-      </p>
-
-      <h2>Legacy Icons (Migrate away from these)</h2>
-      ${LEGACY_ICON_EXAMPLE_LIST}
-    </div>
-  </gux-tab-panel>
-  <gux-tab-panel tab-id="1-4">
-    <div>
-      <h2>Restricted</h2>
-      <p>
-        These icons have carefully defined uses and require approval from the
-        Spark team to apply.
-        <a
-          href="https://form.asana.com/?k=wsglJ3RA89wMSdgRyoGdQg&d=12075379665713"
-          target="_blank"
-          >Request the use of a restricted icon</a
-        >
-      </p>
-
-      <h2>Restricted Icons (Approval required before use)</h2>
-      ${RESTRICTED_ICON_EXAMPLE_LIST}
-    </div>
-  </gux-tab-panel>
-  <gux-tab-panel tab-id="1-5">
-    <div>
-      <h2>Deprecated</h2>
-      <p>These icons have been deprecated.</p>
-
-      ${DEPRECATED_ICON_EXAMPLE_LIST}
-    </div>
-  </gux-tab-panel>
-</gux-tabs>
+<h2>Caching</h2>
+<div>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-left-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-center-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-right-regular"
+    decorative
+  ></gux-icon>
+</div>
+<hr />
+<div>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-left-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-center-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-right-regular"
+    decorative
+  ></gux-icon>
+</div>
+<hr />
+<div>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-left-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-center-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-right-regular"
+    decorative
+  ></gux-icon>
+</div>
+<hr />
+<div>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-left-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-center-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-right-regular"
+    decorative
+  ></gux-icon>
+</div>
+<hr />
+<div>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-left-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-center-regular"
+    decorative
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="fa/align-right-regular"
+    decorative
+  ></gux-icon>
+</div>
+<hr />
+<div>
+  <gux-icon
+    size="large"
+    icon-name="user"
+    screenreader-text="user-01"
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="user"
+    screenreader-text="user-02"
+  ></gux-icon>
+  <gux-icon
+    size="large"
+    icon-name="user"
+    screenreader-text="user-03"
+  ></gux-icon>
+</div>
+<p>Duplicated icons should not require additional network calls</p>
 
 <style
   onload="(function () {
@@ -286,13 +200,13 @@
   .icons-container {
     display: flex;
     flex-wrap: wrap;
+    gap: 5px;
     width: 100%;
   }
 
   .icon-example {
     width: 200px;
     height: 100px;
-    margin: 5px;
     text-align: center;
   }
 </style>

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/example.html
@@ -1,7 +1,8 @@
 <h1>gux-icon</h1>
 
-<nav class="icon-nav">
+<nav>
   <ul>
+    <li><a href="gux-icon.html" aria-current="page">Usage Guidelines</a></li>
     <li><a href="gux-icon-current.html">Current icons</a></li>
     <li><a href="gux-icon-spark.html">Spark icons</a></li>
     <li><a href="gux-icon-restricted.html">Restricted icons</a></li>

--- a/web-apps/genesys-spark-examples/webpack.config.js
+++ b/web-apps/genesys-spark-examples/webpack.config.js
@@ -69,6 +69,17 @@ module.exports = {
           },
           transform: generateComponentPage
         },
+
+        {
+          from: '../../packages/genesys-spark-components/src/components/**/docs/*.html',
+          to: ({ absoluteFilename }) => {
+            const segments = absoluteFilename.split(path.sep);
+            const component = segments[segments.length - 3];
+            const page = segments[segments.length - 1];
+            return `${component}-${page}`;
+          },
+          transform: generateComponentPage
+        },
         {
           from: '../../packages/genesys-spark/src/style/examples/*.html',
           to: ({ absoluteFilename }) => {


### PR DESCRIPTION
Too many icons on a single page takes too long to render (if they even render at all).
So I've split the icons into multiple pages.
Pages placed inside a 'docs' folder are generated & can be linked to.

Not perfect but it's an improvement.
Maybe other components could do with having sub-pages.
I will take another look at improving this in the near future, maybe an improved nav or adding them to the menu.