### PR TITLE
chore(popover): Added role and arialDescribeby to popover and popover-list [WIP]

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/example.html
@@ -1,21 +1,43 @@
 <h1>gux-popover-list</h1>
 <div class="scroll-container">
   <div class="scroll-interior">
-    <div id="popover-target">Example Element</div>
+    <gux-button
+      id="popover-target"
+      accent="primary"
+      aria-describedby="popover-list-content-1"
+      onclick="notify(event)"
+    >
+      Click to open popover-list</gux-button
+    >
+
     <gux-popover-list
       id="popover-example"
       position="top"
       for="popover-target"
-      is-open
+      is-open="false"
     >
-      <gux-list>
-        <gux-list-item onclick="notify(event, 'item-1')">Item 1</gux-list-item>
-        <gux-list-item onclick="notify(event, 'item-2')">Item 2</gux-list-item>
-        <gux-list-item onclick="notify(event, 'item-3')">Item 3</gux-list-item>
-        <gux-list-item onclick="notify(event, 'item-4')">Item 4</gux-list-item>
-        <gux-list-item onclick="notify(event, 'item-5')">Item 5</gux-list-item>
-        <gux-list-item onclick="notify(event, 'item-6')">Item 6</gux-list-item>
-      </gux-list>
+      <div id="popover-list-content-1">
+        <gux-list>
+          <gux-list-item onclick="notify(event, 'item-1')"
+            >Item 1</gux-list-item
+          >
+          <gux-list-item onclick="notify(event, 'item-2')"
+            >Item 2</gux-list-item
+          >
+          <gux-list-item onclick="notify(event, 'item-3')"
+            >Item 3</gux-list-item
+          >
+          <gux-list-item onclick="notify(event, 'item-4')"
+            >Item 4</gux-list-item
+          >
+          <gux-list-item onclick="notify(event, 'item-5')"
+            >Item 5</gux-list-item
+          >
+          <gux-list-item onclick="notify(event, 'item-6')"
+            >Item 6</gux-list-item
+          >
+        </gux-list>
+      </div>
     </gux-popover-list>
   </div>
 </div>
@@ -25,7 +47,7 @@
   const popoverTarget = document.getElementById('popover-target');
   const popoverExample = document.getElementById('popover-example');
 
-  popoverTarget.addEventListener('mouseover', () => {
+  popoverTarget.addEventListener('click', () => {
     popoverExample.isOpen = true;
   });
 })()"
@@ -47,7 +69,6 @@
 
   #popover-target {
     position: absolute;
-    top: 250px;
     left: 250px;
     display: inline-block;
     padding: 10px 15px;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
@@ -35,7 +35,7 @@ export class GuxPopoverList {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
-  private id: string = randomHTMLId('gux-tooltip');
+  private id: string = randomHTMLId('gux-popover-list');
 
   @Element()
   private root: HTMLElement;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
@@ -205,6 +205,8 @@ export class GuxPopoverList {
           'gux-hidden': !this.isOpen,
           'gux-popover-wrapper': true
         }}
+        role="dialog"
+        aria-describedby="gux-popover-content"
         data-placement
       >
         <div

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
@@ -17,7 +17,6 @@ import {
   Placement,
   shift
 } from '@floating-ui/dom';
-import { randomHTMLId } from '@utils/dom/random-html-id';
 import { OnClickOutside } from '@utils/decorator/on-click-outside';
 import { trackComponent } from '@utils/tracking/usage';
 import { findElementById } from '@utils/dom/find-element-by-id';
@@ -35,7 +34,6 @@ export class GuxPopoverList {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
-  private id: string = randomHTMLId('gux-popover-list');
 
   @Element()
   private root: HTMLElement;
@@ -207,7 +205,6 @@ export class GuxPopoverList {
           'gux-popover-wrapper': true
         }}
         role="dialog"
-        aria-describedby={this.id}
         data-placement
       >
         <div
@@ -219,7 +216,7 @@ export class GuxPopoverList {
             onClick={this.dismiss.bind(this)}
           ></gux-dismiss-button>
         )}
-        <div id={this.id} class="gux-popover-content">
+        <div class="gux-popover-content">
           <slot />
         </div>
       </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/gux-popover-list.tsx
@@ -17,7 +17,7 @@ import {
   Placement,
   shift
 } from '@floating-ui/dom';
-
+import { randomHTMLId } from '@utils/dom/random-html-id';
 import { OnClickOutside } from '@utils/decorator/on-click-outside';
 import { trackComponent } from '@utils/tracking/usage';
 import { findElementById } from '@utils/dom/find-element-by-id';
@@ -35,6 +35,7 @@ export class GuxPopoverList {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
+  private id: string = randomHTMLId('gux-tooltip');
 
   @Element()
   private root: HTMLElement;
@@ -206,7 +207,7 @@ export class GuxPopoverList {
           'gux-popover-wrapper': true
         }}
         role="dialog"
-        aria-describedby="gux-popover-content"
+        aria-describedby={this.id}
         data-placement
       >
         <div
@@ -218,7 +219,7 @@ export class GuxPopoverList {
             onClick={this.dismiss.bind(this)}
           ></gux-dismiss-button>
         )}
-        <div class="gux-popover-content">
+        <div id={this.id} class="gux-popover-content">
           <slot />
         </div>
       </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`gux-popover-list #render should render popover 1`] = `
 <gux-popover-list for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div class="gux-popover-wrapper" data-placement>
+    <div aria-describedby="gux-popover-content" class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow"></div>
       <div class="gux-popover-content">
         <slot></slot>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`gux-popover-list #render should render popover 1`] = `
 <gux-popover-list for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div aria-describedby="gux-popover-list-i" class="gux-popover-wrapper" data-placement role="dialog">
+    <div class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow"></div>
-      <div class="gux-popover-content" id="gux-popover-list-i">
+      <div class="gux-popover-content">
         <slot></slot>
       </div>
     </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover-list/tests/__snapshots__/gux-popover-list.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`gux-popover-list #render should render popover 1`] = `
 <gux-popover-list for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div aria-describedby="gux-popover-content" class="gux-popover-wrapper" data-placement role="dialog">
+    <div aria-describedby="gux-popover-list-i" class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow"></div>
-      <div class="gux-popover-content">
+      <div class="gux-popover-content" id="gux-popover-list-i">
         <slot></slot>
       </div>
     </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -1,17 +1,26 @@
 <h1>gux-popover</h1>
+
 <div class="scroll-container">
   <div class="scroll-interior">
-    <div id="popover-target">Example Element</div>
+    <gux-button
+      id="popover-target"
+      accent="primary"
+      aria-describedby="popover-content-1"
+      onclick="notify(event)"
+    >
+      Click to open popover</gux-button
+    >
+
     <gux-popover
       id="popover-example"
       position="top"
       for="popover-target"
-      is-open
+      is-open="false"
     >
       <span slot="title">Title</span>
       <div class="popover-content-wrapper">
         <div>Popover Content</div>
-        <div class="popover-content">
+        <div id="popover-content-1" class="popover-content">
           <gux-button accent="ghost" onclick="notify(event)">
             Action 3
           </gux-button>
@@ -32,7 +41,7 @@
   const popoverTarget = document.getElementById('popover-target');
   const popoverExample = document.getElementById('popover-example');
 
-  popoverTarget.addEventListener('mouseover', () => {
+  popoverTarget.addEventListener('click', () => {
     popoverExample.isOpen = true;
   });
 })()"
@@ -67,7 +76,6 @@
 
   #popover-target {
     position: absolute;
-    top: 250px;
     left: 250px;
     display: inline-block;
     padding: 10px 15px;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -22,6 +22,7 @@ import { OnClickOutside } from '@utils/decorator/on-click-outside';
 import { trackComponent } from '@utils/tracking/usage';
 import { getSlot } from '@utils/dom/get-slot';
 import { findElementById } from '@utils/dom/find-element-by-id';
+import { randomHTMLId } from '@utils/dom/random-html-id';
 
 /**
  * @slot - popover content
@@ -37,6 +38,7 @@ export class GuxPopover {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
+  private id: string = randomHTMLId('gux-tooltip');
 
   @Element()
   private root: HTMLElement;
@@ -252,7 +254,7 @@ export class GuxPopover {
           'gux-popover-wrapper': true
         }}
         role="dialog"
-        aria-describedby="gux-popover-content"
+        aria-describedby={this.id}
         data-placement
       >
         <div
@@ -265,7 +267,7 @@ export class GuxPopover {
           <slot name="title"></slot>
           {this.renderDismissButton()}
         </div>
-        <div class="gux-popover-content">
+        <div id={this.id} class="gux-popover-content">
           <slot />
         </div>
       </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -38,7 +38,7 @@ export class GuxPopover {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
-  private id: string = randomHTMLId('gux-tooltip');
+  private id: string = randomHTMLId('gux-popover');
 
   @Element()
   private root: HTMLElement;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -251,6 +251,8 @@ export class GuxPopover {
           'gux-hidden': !this.isOpen,
           'gux-popover-wrapper': true
         }}
+        role="dialog"
+        aria-describedby="gux-popover-content"
         data-placement
       >
         <div

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -22,7 +22,6 @@ import { OnClickOutside } from '@utils/decorator/on-click-outside';
 import { trackComponent } from '@utils/tracking/usage';
 import { getSlot } from '@utils/dom/get-slot';
 import { findElementById } from '@utils/dom/find-element-by-id';
-import { randomHTMLId } from '@utils/dom/random-html-id';
 
 /**
  * @slot - popover content
@@ -38,7 +37,6 @@ export class GuxPopover {
   private popupElement: HTMLDivElement;
   private arrowElement: HTMLDivElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
-  private id: string = randomHTMLId('gux-popover');
 
   @Element()
   private root: HTMLElement;
@@ -254,7 +252,6 @@ export class GuxPopover {
           'gux-popover-wrapper': true
         }}
         role="dialog"
-        aria-describedby={this.id}
         data-placement
       >
         <div
@@ -267,7 +264,7 @@ export class GuxPopover {
           <slot name="title"></slot>
           {this.renderDismissButton()}
         </div>
-        <div id={this.id} class="gux-popover-content">
+        <div class="gux-popover-content">
           <slot />
         </div>
       </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`gux-popover #render should render popover 1`] = `
 <gux-popover for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div aria-describedby="gux-popover-i" class="gux-popover-wrapper" data-placement role="dialog">
+    <div class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow">
         <div class="gux-arrow-caret"></div>
       </div>
       <div class="gux-popover-header">
         <slot name="title"></slot>
       </div>
-      <div class="gux-popover-content" id="gux-popover-i">
+      <div class="gux-popover-content">
         <slot></slot>
       </div>
     </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`gux-popover #render should render popover 1`] = `
 <gux-popover for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div class="gux-popover-wrapper" data-placement>
+    <div aria-describedby="gux-popover-content" class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow">
         <div class="gux-arrow-caret"></div>
       </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`gux-popover #render should render popover 1`] = `
 <gux-popover for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div aria-describedby="gux-popover-content" class="gux-popover-wrapper" data-placement role="dialog">
+    <div aria-describedby="gux-popover-i" class="gux-popover-wrapper" data-placement role="dialog">
       <div class="gux-arrow">
         <div class="gux-arrow-caret"></div>
       </div>
       <div class="gux-popover-header">
         <slot name="title"></slot>
       </div>
-      <div class="gux-popover-content">
+      <div class="gux-popover-content" id="gux-popover-i">
         <slot></slot>
       </div>
     </div>


### PR DESCRIPTION
This PR is on hold until this other PR is merged: https://github.com/MyPureCloud/genesys-spark/pull/627

Added role and arialDescribeby to popover and popover-list. You can use apple voiceover to confirm that when moving focus or opening a popover on the screen that the screenreader will say the popover element is a dialog and will read the content elements aloud. 

✅ Closes: COMUI-798