### PR TITLE
fix(popover): Fixed gux-popover dismiss logic on focus out

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -92,9 +92,9 @@ export class GuxPopover {
       return;
     }
 
-    const focusIsOutsidePopover = !this.root.contains(
-      event.relatedTarget as Node
-    );
+    const focusIsOutsidePopover =
+      event.relatedTarget && !this.root.contains(event.relatedTarget as Node);
+
     if (focusIsOutsidePopover) {
       this.dismiss();
     }


### PR DESCRIPTION
There was an issue when clicking an element within the popover after focus is on another element within the popover was triggering the focus out event and closing the popover, which wasn't expected behavior. This PR fixes this issue.

✅ Closes: COMUI-1471