### PR TITLE
fix(popover): Fixed accessibility focus issues with gux-popover (FEEDBACK)

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -17,9 +17,9 @@
       <div class="popover-content-wrapper">
         <div>Popover Content</div>
         <div class="popover-content">
-          <gux-button accent="ghost" onclick="notify(event)">
-            Action 3
-          </gux-button>
+          <gux-button-slot accent="ghost">
+            <button type="button" autofocus>Action 3</button>
+          </gux-button-slot>
           <gux-button accent="secondary" onclick="notify(event)">
             Action 2
           </gux-button>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -2,6 +2,11 @@
 <div class="scroll-container">
   <div class="scroll-interior">
     <div id="popover-target">Example Element</div>
+
+    <div class="open-popover">
+      <button id="open-popover">Open Popover</button>
+    </div>
+
     <gux-popover
       id="popover-example"
       position="top"
@@ -31,8 +36,13 @@
   onload="(function () {
   const popoverTarget = document.getElementById('popover-target');
   const popoverExample = document.getElementById('popover-example');
+  const openPopover = document.getElementById('open-popover');
 
   popoverTarget.addEventListener('mouseover', () => {
+    popoverExample.isOpen = true;
+  });
+
+  openPopover.addEventListener('click', () => {
     popoverExample.isOpen = true;
   });
 })()"
@@ -74,5 +84,9 @@
     background-color: #fdfdfd;
     border: 1px #e4e9f0;
     box-shadow: 0 0 2px fade(#202937, 24%);
+  }
+
+  .open-popover {
+    padding: 10px;
   }
 </style>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -4,7 +4,7 @@
     <div id="popover-target">Example Element</div>
 
     <div class="open-popover">
-      <button id="open-popover">Open Popover</button>
+      <gux-button id="open-popover" accent="primary">Open Popover</gux-button>
     </div>
 
     <gux-popover

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -17,9 +17,9 @@
       <div class="popover-content-wrapper">
         <div>Popover Content</div>
         <div class="popover-content">
-          <gux-button-slot accent="ghost">
-            <button type="button" autofocus>Action 3</button>
-          </gux-button-slot>
+          <gux-button accent="ghost" onclick="notify(event)">
+            Action 3
+          </gux-button>
           <gux-button accent="secondary" onclick="notify(event)">
             Action 2
           </gux-button>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
@@ -1,13 +1,3 @@
-@use '~genesys-spark/src/style/focus.scss';
-
-.gux-popover-content {
-  &:focus-visible {
-    @include focus.gux-focus-ring;
-
-    border-radius: var(--gse-semantic-focusRing-cornerRadius);
-  }
-}
-
 .gux-popover-wrapper {
   position: absolute;
   top: 0;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
@@ -1,3 +1,13 @@
+@use '~genesys-spark/src/style/focus.scss';
+
+.gux-popover-content {
+  &:focus-visible {
+    @include focus.gux-focus-ring;
+
+    border-radius: var(--gse-semantic-focusRing-cornerRadius);
+  }
+}
+
 .gux-popover-wrapper {
   position: absolute;
   top: 0;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.scss
@@ -1,3 +1,13 @@
+@use '~genesys-spark/src/style/focus.scss';
+
+.gux-popover-content {
+  &:focus-visible,
+  :focus {
+    outline: none;
+    box-shadow: none;
+  }
+}
+
 .gux-popover-wrapper {
   position: absolute;
   top: 0;
@@ -8,6 +18,7 @@
   padding: var(--gse-ui-popover-gap);
   background-color: var(--gse-ui-popover-backgroundColor);
   border-radius: var(--gse-ui-popover-borderRadius);
+  outline: none;
   box-shadow: var(--gse-ui-popover-boxShadow-x)
     var(--gse-ui-popover-boxShadow-y) var(--gse-ui-popover-boxShadow-blur)
     var(--gse-ui-popover-boxShadow-spread) var(--gse-ui-tooltip-boxShadow-color);

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -235,25 +235,7 @@ export class GuxPopover {
 
   private focusFirstSlottedElement(): void {
     this.contentElement.focus();
-
-    // TODO: should we dynamically focus first focusable elemtn in the slotted content?
-    //
-    // // Focus the first focusable element in the slotted content
-    // const contentElementChildren = this.getRootChildren(this.contentElement);
-    // if (contentElementChildren?.length) {
-    //   const firstChild = this.getRootChildren(this.contentElement)[0] as HTMLElement;
-    //   const firstSlottedInput = firstChild.querySelector(
-    //     'gux-button gux-dropdown'
-    //   ) as HTMLElement;
-    //   firstSlottedInput.focus();
-    // }
   }
-
-  // private getRootChildren(root: HTMLElement): Element[] {
-  //   const slot = root.querySelector('slot');
-
-  //   return slot ? slot.assignedElements() : Array.from(root.children);
-  // }
 
   disconnectedCallback(): void {
     if (this.cleanupUpdatePosition) {
@@ -296,6 +278,7 @@ export class GuxPopover {
         <div
           ref={(el: HTMLDivElement) => (this.contentElement = el)}
           class="gux-popover-content"
+          tabIndex={0}
         >
           <slot />
         </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -218,7 +218,7 @@ export class GuxPopover {
   componentDidLoad(): void {
     if (this.isOpen) {
       this.runUpdatePosition();
-      this.focusFirstSlottedElement();
+      this.contentElement.focus();
     }
   }
 
@@ -226,15 +226,11 @@ export class GuxPopover {
     this.lastActiveElement = document.activeElement as HTMLElement;
 
     if (this.isOpen) {
-      this.focusFirstSlottedElement();
+      this.contentElement.focus();
       this.runUpdatePosition();
     } else if (this.cleanupUpdatePosition) {
       this.cleanupUpdatePosition();
     }
-  }
-
-  private focusFirstSlottedElement(): void {
-    this.contentElement.focus();
   }
 
   disconnectedCallback(): void {

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -276,6 +276,7 @@ export class GuxPopover {
     return (
       <div
         ref={(el: HTMLDivElement) => (this.popupElement = el)}
+        aria-expanded={this.isOpen.toString()}
         class={{
           'gux-hidden': !this.isOpen,
           'gux-popover-wrapper': true

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -31,7 +31,7 @@ import { findElementById } from '@utils/dom/find-element-by-id';
 @Component({
   styleUrl: 'gux-popover.scss',
   tag: 'gux-popover',
-  shadow: { delegatesFocus: true }
+  shadow: true
 })
 export class GuxPopover {
   private popupElement: HTMLDivElement;

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -275,6 +275,7 @@ export class GuxPopover {
           ref={(el: HTMLDivElement) => (this.contentElement = el)}
           class="gux-popover-content"
           tabIndex={0}
+          aria-label="Popover content"
         >
           <slot />
         </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -31,7 +31,7 @@ import { findElementById } from '@utils/dom/find-element-by-id';
 @Component({
   styleUrl: 'gux-popover.scss',
   tag: 'gux-popover',
-  shadow: true
+  shadow: { delegatesFocus: true }
 })
 export class GuxPopover {
   private popupElement: HTMLDivElement;
@@ -295,7 +295,6 @@ export class GuxPopover {
         </div>
         <div
           ref={(el: HTMLDivElement) => (this.contentElement = el)}
-          tabIndex={0}
           class="gux-popover-content"
         >
           <slot />

--- a/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`gux-popover #render should render popover 1`] = `
 <gux-popover for="popover-target" id="popover-example" is-open="" position="top">
   <mock:shadow-root>
-    <div class="gux-popover-wrapper" data-placement>
+    <div aria-expanded="true" class="gux-popover-wrapper" data-placement>
       <div class="gux-arrow">
         <div class="gux-arrow-caret"></div>
       </div>
       <div class="gux-popover-header">
         <slot name="title"></slot>
       </div>
-      <div class="gux-popover-content">
+      <div aria-label="Popover content" class="gux-popover-content" tabindex="0">
         <slot></slot>
       </div>
     </div>


### PR DESCRIPTION
Fixed some accessibility issues with the popover component COMUI-824 has more info about the 3 accessibility issues fixed in this PR)

There is now logic to focus on the popover content container element after the user opens the popover via clicking a target element. I tell the screenreader about this focused content container element with an aria-label attribute.

✅ Closes: COMUI-824