### PR TITLE
fix(form-field-radio-group): update radio group spacing

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
@@ -1,6 +1,4 @@
-<h1>gux-form-field-radio</h1>
-
-<p>slot a input[type=radio] element into a gux-form-field-radio element</p>
+<h1>gux-form-field-radio-group-beta</h1>
 
 <h2>Example</h2>
 <form onchange="notify(event)" oninput="notify(event)">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/gux-form-field-radio-group.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/gux-form-field-radio-group.scss
@@ -15,6 +15,14 @@
   display: block;
 }
 
+::slotted(gux-form-field-radio) {
+  padding-top: var(--gse-ui-formControl-group-gapItems);
+}
+
+::slotted(gux-form-field-radio:first-of-type) {
+  padding-top: 0;
+}
+
 :host([disabled]) {
   .gux-form-field-legend-label {
     opacity: var(--gse-ui-formControl-input-disabled-opacity);

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/readme.md
@@ -1,4 +1,4 @@
-# gux-form-field-radio
+# gux-form-field-radio-group-beta
 
 
 

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/tests/gux-form-field-radio-group.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/tests/gux-form-field-radio-group.e2e.ts
@@ -4,13 +4,7 @@ import {
   a11yCheck
 } from '../../../../../../test/e2eTestUtils';
 
-const axeExclusions = [
-  {
-    issueId: 'target-size',
-    exclusionReason:
-      'COMUI-2949 Fix any of the following: Target has insufficient size (16px by 16px, should be at least 24px by 24px); Target has insufficient space to its closest neighbors. Safe clickable space has a diameter of 20px instead of at least 24px.'
-  }
-];
+const axeExclusions = [];
 
 async function newNonrandomE2EPage({
   html

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.scss
@@ -29,6 +29,7 @@
 
 :host {
   display: block;
+  padding-top: 4px;
 }
 
 :host(.gux-disabled) {
@@ -59,7 +60,6 @@
   display: flex;
   flex-direction: row;
   gap: var(--gse-ui-radioButton-helper-gap);
-  padding-top: 4px;
 
   .gux-label {
     display: flex;


### PR DESCRIPTION
Does anyone know why the following does not set the `padding-top` of the first `gux-form-field-radio` element to 0? I just need a way to set the padding top of all the slotted `gux-form-field-radio` elements except the first and I cannot get it to work. any input would be appreciated, thanks
```
::slotted(gux-form-field-radio) {
  padding-top: var(--gse-ui-formControl-group-gapItems);

  &:first-child {
    padding-top: 0;
  }
}
```