### PR TITLE
fix(form-field-select): clicking downarrow now displays the dropdown

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.scss
@@ -22,7 +22,8 @@
   align-self: auto;
   order: 0;
   width: 100%;
-  margin-left: var(--gse-ui-formControl-input-gap);
+  height: var(--gse-ui-formControl-input-textfield-height);
+  padding-left: var(--gse-ui-formControl-input-gap);
   color: var(--gse-ui-formControl-input-populatedColor);
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -52,7 +53,6 @@
       place-content: stretch center;
       align-items: center;
       width: 100%;
-      height: var(--gse-ui-formControl-input-textfield-height);
       font-family: var(--gse-ui-formControl-input-contentText-fontFamily);
       font-size: var(--gse-ui-formControl-input-contentText-fontSize);
       font-weight: var(--gse-ui-formControl-input-contentText-fontWeight);
@@ -77,9 +77,12 @@
       }
 
       gux-icon {
+        position: absolute;
+        top: 0;
+        right: 0;
         width: var(--gse-ui-formControl-input-inputIcon-size);
         height: var(--gse-ui-formControl-input-inputIcon-size);
-        margin-right: var(--gse-ui-formControl-input-gap);
+        margin: var(--gse-ui-formControl-input-padding);
         pointer-events: none;
       }
 


### PR DESCRIPTION
Ticket : https://inindca.atlassian.net/browse/COMUI-2955

This issue also exists in other components such as `form-field-number` , `form-field-phone`, `form-field-text-like`.  I wanted to discuss here before making changes to these components also.

The issue is that the slotted `input` in these components only has a height of 16px whereas the parent of the slotted input which is `.gux-input-container` class has a height of 32px meaning that if you are to click in any area outside of the 16px height bounds of the slotted input it wont select that component. I have attatched an image below as an example,

![Screenshot 2024-07-09 at 09 09 14](https://github.com/MyPureCloud/genesys-spark/assets/101644078/b2889d39-4746-44ae-ae66-394c3d1fef46)

I think to fix this issue we would instead need to apply the 32px height to the actual slotted input and not the `.gux-input-container` class.






✅ Closes: COMUI-2955