### PR TITLE
style(copy-to-clipboard): Constrain width of copy-to-clipboard component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### Bug Fixes
+
+* **copy-to-clipboard:** contrain max-width of component and min-width of copy icon ([202c3d9](https://github.com/harter-genesys/genesys-spark/commit/202c3d931fdad696968b72296ca28105b11f9858))
+
+### [4.64.1](https://github.com/MyPureCloud/genesys-spark/compare/v4.63.1...v4.63.2) (2024-07-02)
+
 ## [4.64.0](https://github.com/MyPureCloud/genesys-spark/compare/v4.63.3...v4.64.0) (2024-07-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-spark-components",
-  "version": "4.64.0",
+  "version": "4.64.1",
   "description": "Common webcomponents",
   "license": "MIT",
   "scripts": {

--- a/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/gux-copy-to-clipboard.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/gux-copy-to-clipboard.scss
@@ -17,11 +17,13 @@ button {
 .gux-copy-to-clipboard-wrapper {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
 
   .gux-copy-content {
     display: inherit;
     gap: var(--gse-ui-copyToClipboard-contentContainer-gap);
     align-items: inherit;
+    max-width: 100%;
     cursor: pointer;
 
     ::slotted(*) {
@@ -42,6 +44,7 @@ button {
     gux-icon[icon-name='copy'] {
       flex-shrink: 0;
       width: var(--gse-ui-icon-size-sm);
+      min-width: 22px;
       height: var(--gse-ui-icon-size-sm);
       padding: var(--gse-ui-copyToClipboard-iconContainer-padding);
       visibility: hidden;


### PR DESCRIPTION
Set max-width to 100% for copy-to-clipboard component.  Set min-width of icon in copy-to-clipboard-component.

✅ Closes: COMUI-2961
Before:
![before-copy-to-clipboard-with-truncate](https://github.com/MyPureCloud/genesys-spark/assets/158307014/57682566-4984-484b-b11c-9856695c8b85)

After:
![copy-to-clipboard-with-truncate](https://github.com/MyPureCloud/genesys-spark/assets/158307014/65efb055-293d-49c4-b152-5bb026fe0484)
