### PR TITLE
fix(table): disabled pagination overlapping context-menu

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-table.scss
@@ -1,8 +1,9 @@
 @use '~genesys-spark/src/style/typography.scss';
 
 :host {
+  position: relative;
+  z-index: var(--gse-semantic-zIndex-sticky);
   display: block;
-  isolation: isolate;
 
   .gux-table {
     position: relative;


### PR DESCRIPTION
**Ticket** :  https://inindca.atlassian.net/browse/COMUI-2951

**Reproduction Steps:**
    1. Go to `gux-context-menu` and  under the `Table Example` click the furtherest right arrow on the pagination so that the arrow buttons are now disabled. Then click the `gux-context-menu` to open and the issue should appear. See screenshot below,
    
![Screenshot 2024-07-11 at 09 53 02](https://github.com/MyPureCloud/genesys-spark/assets/101644078/9ca04757-aff7-4b50-be29-71ff6251f002)

**Issue** 
   1. This issue is being caused due to the opacity property being set on the disabled element. If the opacity property has a value of less than `1` it will create a new stacking context as see in the screenshot above. Outlined here (https://www.w3.org/TR/css-color-3/#transparency)

**Resolution**
The `gux-table` uses the `isolation:isolate` property which was introduced to fix https://inindca.atlassian.net/browse/COMUI-562.

The `isolation` property with a value of `isolate` will create a new stacking context isolating the element and its descendants from other stacking contexts. So if we are isolating the descendants also this will prevent the `gux-context-menu` from appearing on top even with a `z-index` of 100. It basically will put this element in a seperate layer preventing the `z-index` from working.

I think the best way to resolve this is instead use a `position` of `relative` and set the `z-index` of `1` on the table so it will resolve both this issue and wont regress COMUI-562 as it will be in the same context.