### PR TITLE
fix(form-field-file): Remove duplication in screenreader content

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/example.html
@@ -18,8 +18,8 @@
       <label slot="label">Upload a profile picture</label>
       <input
         type="file"
-        id="avatar"
-        name="avatar"
+        id="avatar2"
+        name="avatar2"
         accept="image/png, image/jpeg"
         slot="input"
       />
@@ -32,8 +32,8 @@
       <label slot="label">Upload a profile picture</label>
       <input
         type="file"
-        id="avatar"
-        name="avatar"
+        id="avatar3"
+        name="avatar3"
         accept="image/png, image/jpeg"
         slot="input"
         disabled
@@ -47,8 +47,8 @@
       <label slot="label">Upload a profile picture</label>
       <input
         type="file"
-        id="avatar"
-        name="avatar"
+        id="avatar4"
+        name="avatar4"
         accept="image/png, image/jpeg"
         slot="input"
         required
@@ -62,8 +62,8 @@
       <label slot="label">Upload a profile picture</label>
       <input
         type="file"
-        id="avatar"
-        name="avatar"
+        id="avatar5"
+        name="avatar5"
         accept="image/png, image/jpeg"
         slot="input"
       />
@@ -77,8 +77,8 @@
       <label slot="label">Upload a profile picture</label>
       <input
         type="file"
-        id="avatar"
-        name="avatar"
+        id="avatar6"
+        name="avatar6"
         accept="image/png, image/jpeg"
         slot="input"
       />

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/gux-form-field-file.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/gux-form-field-file.scss
@@ -1,12 +1,12 @@
 @use '../../gux-form-field.scss';
-@use '../../functional-components/gux-form-field-fieldset-container/gux-form-field-fieldset-container.scss';
+@use '../../functional-components/gux-form-field-container/gux-form-field-container.scss';
 @use '../../functional-components/gux-form-field-error/gux-form-field-error.scss';
-@use '../../functional-components/gux-form-field-legend-label/gux-form-field-legend-label.scss';
+@use '../../functional-components/gux-form-field-label/gux-form-field-label.scss';
 @use '../../functional-components/gux-form-field-help/gux-form-field-help.scss';
 
-@include gux-form-field-fieldset-container.Style;
+@include gux-form-field-container.Style;
 @include gux-form-field-error.Style;
-@include gux-form-field-legend-label.Style;
+@include gux-form-field-label.Style;
 @include gux-form-field-help.Style;
 
 :host {

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/gux-form-field-file.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/gux-form-field-file.tsx
@@ -1,14 +1,12 @@
 import { Component, State, Element, JSX, Prop, h } from '@stencil/core';
-import { buildI18nForComponent, GetI18nValue } from 'i18n';
-import { ILocalizedComponentResources } from '../../../../../i18n/fetchResources';
 import { OnMutation } from '@utils/decorator/on-mutation';
 import { hasSlot } from '@utils/dom/has-slot';
 import { trackComponent } from '@utils/tracking/usage';
 import {
   GuxFormFieldError,
-  GuxFormFieldFieldsetContainer,
+  GuxFormFieldContainer,
   GuxFormFieldHelp,
-  GuxFormFieldLegendLabel
+  GuxFormFieldLabel
 } from '../../functional-components/functional-components';
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
@@ -16,8 +14,6 @@ import {
   getSlottedInput,
   validateFormIds
 } from '../../gux-form-field.service';
-import { getSlotTextContent } from '@utils/dom/get-slot-text-content';
-import componentResources from './i18n/en.json';
 import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
 import { onRequiredChange } from '@utils/dom/on-attribute-change';
 
@@ -34,7 +30,6 @@ import { onRequiredChange } from '@utils/dom/on-attribute-change';
   shadow: true
 })
 export class GuxFormFieldFile {
-  private getI18nValue: GetI18nValue;
   private fileInputElement: HTMLInputElement;
   private label: HTMLLabelElement;
   private requiredObserver: MutationObserver;
@@ -63,12 +58,7 @@ export class GuxFormFieldFile {
     this.hasHelp = hasSlot(this.root, 'help');
   }
 
-  async componentWillLoad(): Promise<void> {
-    this.getI18nValue = await buildI18nForComponent(
-      this.root,
-      componentResources as ILocalizedComponentResources
-    );
-
+  componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
@@ -81,17 +71,6 @@ export class GuxFormFieldFile {
   disconnectedCallback(): void {
     if (this.requiredObserver) {
       this.requiredObserver.disconnect();
-    }
-  }
-
-  private renderScreenReaderText(
-    text: string,
-    condition: boolean = true
-  ): JSX.Element {
-    if (condition) {
-      return (
-        <gux-screen-reader-beta>{text}</gux-screen-reader-beta>
-      ) as JSX.Element;
     }
   }
 
@@ -135,26 +114,13 @@ export class GuxFormFieldFile {
 
   render(): JSX.Element {
     return (
-      <GuxFormFieldFieldsetContainer labelPosition={this.computedLabelPosition}>
-        <GuxFormFieldLegendLabel
+      <GuxFormFieldContainer labelPosition={this.computedLabelPosition}>
+        <GuxFormFieldLabel
           position={this.computedLabelPosition}
           required={this.required}
-          labelText={this.label?.textContent}
         >
           <slot name="label" onSlotchange={() => this.setLabel()} />
-          {this.renderScreenReaderText(
-            this.getI18nValue('required'),
-            this.required
-          )}
-          {this.renderScreenReaderText(
-            getSlotTextContent(this.root, 'error'),
-            this.hasError
-          )}
-          {this.renderScreenReaderText(
-            getSlotTextContent(this.root, 'help'),
-            this.hasHelp
-          )}
-        </GuxFormFieldLegendLabel>
+        </GuxFormFieldLabel>
         <slot name="input" onSlotchange={() => this.setInput()} />
         <GuxFormFieldError show={this.hasError}>
           <slot name="error" />
@@ -162,7 +128,7 @@ export class GuxFormFieldFile {
         <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
           <slot name="help" />
         </GuxFormFieldHelp>
-      </GuxFormFieldFieldsetContainer>
+      </GuxFormFieldContainer>
     ) as JSX.Element;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/i18n/en.json
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/i18n/en.json
@@ -1,3 +1,0 @@
-{
-  "required": "required"
-}

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.e2e.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.e2e.ts.snap
@@ -2,32 +2,176 @@
 
 exports[`gux-form-field-file #render help should render component as expected 1`] = `"<gux-form-field-file hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input slot="input" type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" aria-describedby="gux-form-field-help-i"> <span slot="help" id="gux-form-field-help-i">This is a help message </span> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render help should render component as expected 2`] = `null`;
+exports[`gux-form-field-file #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help gux-show">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render input attributes should render component as expected (1) 1`] = `"<gux-form-field-file hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input slot="input" type="file" id="avatar" name="avatar" accept="image/png, image/jpeg"> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render input attributes should render component as expected (1) 2`] = `null`;
+exports[`gux-form-field-file #render input attributes should render component as expected (1) 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render input attributes should render component as expected (2) 1`] = `"<gux-form-field-file hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input slot="input" type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" disabled=""> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render input attributes should render component as expected (2) 2`] = `null`;
+exports[`gux-form-field-file #render input attributes should render component as expected (2) 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render input attributes should render component as expected (3) 1`] = `"<gux-form-field-file hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input slot="input" type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" required=""> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render input attributes should render component as expected (3) 2`] = `null`;
+exports[`gux-form-field-file #render input attributes should render component as expected (3) 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label gux-required">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render label-position should render component as expected (1) 1`] = `"<gux-form-field-file hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" slot="input"> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render label-position should render component as expected (1) 2`] = `null`;
+exports[`gux-form-field-file #render label-position should render component as expected (1) 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render label-position should render component as expected (2) 1`] = `"<gux-form-field-file label-position="above" hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" slot="input"> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render label-position should render component as expected (2) 2`] = `null`;
+exports[`gux-form-field-file #render label-position should render component as expected (2) 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render label-position should render component as expected (3) 1`] = `"<gux-form-field-file label-position="beside" hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" slot="input"> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render label-position should render component as expected (3) 2`] = `null`;
+exports[`gux-form-field-file #render label-position should render component as expected (3) 2`] = `
+<div class="gux-beside gux-form-field-container">
+  <div class="gux-beside gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`gux-form-field-file #render label-position should render component as expected (4) 1`] = `"<gux-form-field-file label-position="screenreader" hydrated=""> <label slot="label" for="avatar">Upload a profile picture</label> <input type="file" id="avatar" name="avatar" accept="image/png, image/jpeg" slot="input"> </gux-form-field-file>"`;
 
-exports[`gux-form-field-file #render label-position should render component as expected (4) 2`] = `null`;
+exports[`gux-form-field-file #render label-position should render component as expected (4) 2`] = `
+<div class="gux-form-field-container gux-screenreader">
+  <div class="gux-form-field-label gux-screenreader">
+    <slot name="label"></slot>
+  </div>
+  <slot name="input"></slot>
+  <div class="gux-form-field-error">
+    <gux-icon hydrated="" icon-name="fa/hexagon-exclamation-solid" size="inherit"></gux-icon>
+    <div class="gux-message">
+      <slot name="error"></slot>
+    </div>
+  </div>
+  <div class="gux-form-field-help">
+    <div class="gux-message">
+      <slot name="help"></slot>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.spec.ts.snap
@@ -3,16 +3,10 @@
 exports[`gux-form-field-file #render help should render component as expected 1`] = `
 <gux-form-field-file>
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
         <slot name="label"></slot>
-        <gux-screen-reader-beta>
-          This is a help message
-        </gux-screen-reader-beta>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -25,7 +19,7 @@ exports[`gux-form-field-file #render help should render component as expected 1`
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -40,13 +34,10 @@ exports[`gux-form-field-file #render help should render component as expected 1`
 exports[`gux-form-field-file #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-file>
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -59,7 +50,7 @@ exports[`gux-form-field-file #render input attributes should render component as
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -71,13 +62,10 @@ exports[`gux-form-field-file #render input attributes should render component as
 exports[`gux-form-field-file #render input attributes should render component as expected (2) 1`] = `
 <gux-form-field-file>
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -90,7 +78,7 @@ exports[`gux-form-field-file #render input attributes should render component as
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -102,16 +90,10 @@ exports[`gux-form-field-file #render input attributes should render component as
 exports[`gux-form-field-file #render input attributes should render component as expected (3) 1`] = `
 <gux-form-field-file>
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label gux-required">
         <slot name="label"></slot>
-        <gux-screen-reader-beta>
-          required
-        </gux-screen-reader-beta>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label gux-required" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -124,7 +106,7 @@ exports[`gux-form-field-file #render input attributes should render component as
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -136,13 +118,10 @@ exports[`gux-form-field-file #render input attributes should render component as
 exports[`gux-form-field-file #render label-position should render component as expected (1) 1`] = `
 <gux-form-field-file>
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -155,7 +134,7 @@ exports[`gux-form-field-file #render label-position should render component as e
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -167,13 +146,10 @@ exports[`gux-form-field-file #render label-position should render component as e
 exports[`gux-form-field-file #render label-position should render component as expected (2) 1`] = `
 <gux-form-field-file label-position="above">
   <mock:shadow-root>
-    <fieldset class="gux-above gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-above gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -186,7 +162,7 @@ exports[`gux-form-field-file #render label-position should render component as e
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -198,13 +174,10 @@ exports[`gux-form-field-file #render label-position should render component as e
 exports[`gux-form-field-file #render label-position should render component as expected (3) 1`] = `
 <gux-form-field-file label-position="beside">
   <mock:shadow-root>
-    <fieldset class="gux-beside gux-form-field-fieldset-container">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-beside gux-form-field-container">
+      <div class="gux-beside gux-form-field-label">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-beside gux-form-field-legend-label" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -217,7 +190,7 @@ exports[`gux-form-field-file #render label-position should render component as e
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture
@@ -229,13 +202,10 @@ exports[`gux-form-field-file #render label-position should render component as e
 exports[`gux-form-field-file #render label-position should render component as expected (4) 1`] = `
 <gux-form-field-file label-position="screenreader">
   <mock:shadow-root>
-    <fieldset class="gux-form-field-fieldset-container gux-screenreader">
-      <legend class="gux-form-field-legend-label gux-screenreader">
+    <div class="gux-form-field-container gux-screenreader">
+      <div class="gux-form-field-label gux-screenreader">
         <slot name="label"></slot>
-      </legend>
-      <span aria-hidden="true" class="gux-form-field-legend-label gux-screenreader" role="presentation">
-        Upload a profile picture
-      </span>
+      </div>
       <slot name="input"></slot>
       <div class="gux-form-field-error">
         <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
@@ -248,7 +218,7 @@ exports[`gux-form-field-file #render label-position should render component as e
           <slot name="help"></slot>
         </div>
       </div>
-    </fieldset>
+    </div>
   </mock:shadow-root>
   <label for="avatar" slot="label">
     Upload a profile picture

--- a/packages/genesys-spark-components/src/i18n/translations/en.json
+++ b/packages/genesys-spark-components/src/i18n/translations/en.json
@@ -92,9 +92,6 @@
   "gux-form-field-dropdown": {
     "required": "Required"
   },
-  "gux-form-field-file": {
-    "required": "required"
-  },
   "gux-form-field-input-clear-button": {
     "clear": "Clear"
   },


### PR DESCRIPTION
✅ Closes: COMUI-2969

This is really small stuff but it helps with the tooltip changes that are coming also. Basically removing some duplication on the screenreader content and changing the example to make the ids unique. 

## Before:
![Screenshot 2024-07-10 at 14 37 22](https://github.com/user-attachments/assets/77265fa8-8c2a-4ed1-88c4-bace371dc493)
![Screenshot 2024-07-16 at 10 33 38](https://github.com/user-attachments/assets/e1611480-21cc-4ddc-b3a0-e11f07f0d912)
![Screenshot 2024-07-16 at 10 34 01](https://github.com/user-attachments/assets/3067fa1f-6204-47e0-ae77-093d659a6a8e)


## After:
![Screenshot 2024-07-16 at 10 40 12](https://github.com/user-attachments/assets/54f9d5a8-6d50-4d5c-b100-163b726dc3bc)
![Screenshot 2024-07-16 at 10 36 44](https://github.com/user-attachments/assets/29274b50-950d-41ef-9e46-fddba0b706db)
![Screenshot 2024-07-16 at 10 37 02](https://github.com/user-attachments/assets/ea7867a6-a10d-42bf-ace2-1e04d31cb237)
