### PR TITLE
fix(datepicker): ensure format is set before updating date

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -168,7 +168,9 @@ export class GuxDatepicker {
 
   @Watch('value')
   watchValue() {
-    this.updateDate();
+    if (this.format) {
+      this.updateDate();
+    }
   }
 
   @Watch('minDate')


### PR DESCRIPTION
Ticket : https://inindca.atlassian.net/browse/COMUI-2873

**RCA** 
What I believe was happening is that the  `Watch('value')` is firing before the `componentWillLoad()` lifecycle function which seems weird but this can happen in scenarios where the `value` is set programmatically like it is in this issue as far as I researched. When the `Watch('value')` is fired it called `this.updateDate()` which needs the `this.format` to be set  which it wont be since the format is set in `componentWillLoad()` I think the two ways around this are to apply an `if` guard to the `Watch('value')` or provide a default format where the state is created. I opted for the `if` guard.

**To be backported**

✅ Closes: COMUI-2873