### PR TITLE
fix(pagination): filter out characters from slotted number input

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-buttons/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-buttons/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx
@@ -98,10 +98,15 @@ export class GuxPaginationEllipsisButton {
 
   private applyInputListener(): void {
     this.inputElement?.addEventListener('keydown', (event: KeyboardEvent) => {
+      const inputValue = (event.target as HTMLInputElement).value.trim();
       if (event.key == 'Enter' || event.key == ' ') {
-        event.preventDefault();
-        this.goToPage.emit((event.target as HTMLInputElement).value);
-        this.isOpen = false;
+        if (inputValue == '') {
+          event.preventDefault();
+        } else {
+          event.preventDefault();
+          this.goToPage.emit((event.target as HTMLInputElement).value);
+          this.isOpen = false;
+        }
       }
     });
   }
@@ -144,6 +149,10 @@ export class GuxPaginationEllipsisButton {
               min="1"
               max={this.totalPages}
               value="1"
+              onKeyDown={evt =>
+                ['e', 'E', '+', '-', '.'].includes(evt.key) &&
+                evt.preventDefault()
+              }
             />
             <label slot="label"></label>
           </gux-form-field-number>


### PR DESCRIPTION


The slotted input of type number within the `gux-pagination` for the `goToPage` functionality allows for extra characters outside of numbers including `e` , `E`, `+`, `.` and `-`. This is normal and part of the native input number. I have filtered out these characters from the input. I have also added the fix to not allow for an empty input to be submitted.

[✅ Closes: COMUI-2991](https://inindca.atlassian.net/browse/COMUI-2991)