### PR TITLE
fix(pagination-beta): filter out characters from slotted number input

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-pagination-beta/gux-pagination-buttons-beta/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-pagination-beta/gux-pagination-buttons-beta/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx
@@ -98,10 +98,15 @@ export class GuxPaginationEllipsisButton {
 
   private applyInputListener(): void {
     this.inputElement?.addEventListener('keydown', (event: KeyboardEvent) => {
+      const inputValue = (event.target as HTMLInputElement).value.trim();
       if (event.key == 'Enter' || event.key == ' ') {
-        event.preventDefault();
-        this.goToPage.emit((event.target as HTMLInputElement).value);
-        this.isOpen = false;
+        if (inputValue == '') {
+          event.preventDefault();
+        } else {
+          event.preventDefault();
+          this.goToPage.emit((event.target as HTMLInputElement).value);
+          this.isOpen = false;
+        }
       }
     });
   }
@@ -142,6 +147,10 @@ export class GuxPaginationEllipsisButton {
               min="1"
               max={this.totalPages}
               value="1"
+              onKeyDown={evt =>
+                ['e', 'E', '+', '-', '.'].includes(evt.key) &&
+                evt.preventDefault()
+              }
             />
             <label slot="label"></label>
           </gux-form-field-number>


### PR DESCRIPTION
I think this should be backported. Backport of https://github.com/MyPureCloud/genesys-spark/pull/545
[COMUI-2991](https://inindca.atlassian.net/browse/COMUI-2991)

[COMUI-2991]: https://inindca.atlassian.net/browse/COMUI-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ