### PR TITLE
feat(time-zone): Add gux-time-zone to v4

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/example.html
@@ -1,0 +1,25 @@
+<h1>gux-time-zone-beta</h1>
+
+<h2>Time Zones</h2>
+
+<h3>Default</h3>
+<gux-time-zone-beta time-zone-id="Etc/GMT"></gux-time-zone-beta>
+
+<h3>Show offset</h3>
+<gux-time-zone-beta
+  time-zone-id="America/Vancouver"
+  offset="true"
+></gux-time-zone-beta>
+
+<h3>Parentheses around offset</h3>
+<gux-time-zone-beta
+  time-zone-id="Antarctica/Vostok"
+  offset="true"
+  surround-offset="true"
+></gux-time-zone-beta>
+
+<h3>Shorten name</h3>
+<gux-time-zone-beta
+  time-zone-id="America/Vancouver"
+  shorten="true"
+></gux-time-zone-beta>

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/gux-time-zone.service.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/gux-time-zone.service.ts
@@ -1,0 +1,19 @@
+import { GuxTimeZoneIdentifier } from '../../../i18n/time-zone/types';
+import { getTimeZoneList, formatOffset } from '../../../utils/date/time-zone';
+import { GuxTimeZoneListing } from '../gux-time-zone-picker/gux-time-zone-picker.types';
+
+export function shortenZone(zone: string): string {
+  const sections = zone.split('/');
+  return sections?.pop() || zone;
+}
+
+export function getLocalizedOffset(
+  localizedUTC: string,
+  timeZoneId: GuxTimeZoneIdentifier
+): string {
+  const zoneList: GuxTimeZoneListing[] = getTimeZoneList();
+  const timeZone = zoneList.find(zone => zone.name === timeZoneId);
+
+  const formattedOffset = formatOffset(timeZone?.currentTimeOffsetInMinutes);
+  return `${localizedUTC}${formattedOffset}`;
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/gux-time-zone.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/gux-time-zone.tsx
@@ -1,0 +1,72 @@
+import { Component, JSX, h, Host, Prop, Element } from '@stencil/core';
+import { trackComponent } from '@utils/tracking/usage';
+import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
+import translationResources from '../gux-time-zone-picker/i18n/en.json';
+import { GuxTimeZoneIdentifier } from '../../../i18n/time-zone/types';
+
+import { getLocalizedOffset, shortenZone } from './gux-time-zone.service';
+
+@Component({
+  tag: 'gux-time-zone-beta',
+  shadow: true
+})
+export class GuxTimeZoneBeta {
+  private i18n: GetI18nValue;
+
+  /**
+   * Reference to the host element.
+   */
+  @Element()
+  root: HTMLElement;
+
+  /**
+   * The id of the time zone to display
+   */
+  @Prop()
+  timeZoneId: GuxTimeZoneIdentifier;
+
+  /**
+   * True to display the zone's offset from UTC
+   */
+  @Prop()
+  offset: boolean;
+
+  /**
+   * True to display surround the offset with parentheses
+   */
+  @Prop()
+  surroundOffset: boolean;
+
+  /**
+   * True to shorten the displayed zone name: 'Europe/London' -> 'London'
+   */
+  @Prop()
+  shorten: boolean;
+
+  private renderZoneDisplay(): JSX.Element | undefined {
+    let localizedZone = this.i18n(this.timeZoneId);
+    if (this.shorten) {
+      localizedZone = shortenZone(localizedZone);
+    }
+    let displayText = localizedZone;
+    if (this.offset) {
+      const localizedUTC = this.i18n('UTC');
+      const localizedOffset = getLocalizedOffset(localizedUTC, this.timeZoneId);
+
+      displayText = `${localizedZone} ${localizedOffset}`;
+      if (this.surroundOffset) {
+        displayText = `${localizedZone} (${localizedOffset})`;
+      }
+    }
+    return (<span>{displayText}</span>) as JSX.Element;
+  }
+
+  async componentWillLoad(): Promise<void> {
+    trackComponent(this.root);
+    this.i18n = await buildI18nForComponent(this.root, translationResources);
+  }
+
+  render() {
+    return (<Host>{this.renderZoneDisplay()}</Host>) as JSX.Element;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/readme.md
@@ -1,0 +1,1 @@
+# gux-time-zone-beta

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/tests/gux-time-zone.service.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/tests/gux-time-zone.service.spec.ts
@@ -1,0 +1,40 @@
+import { getLocalizedOffset, shortenZone } from '../gux-time-zone.service';
+import { GuxTimeZoneIdentifier } from '../../../../i18n/time-zone/types';
+
+interface ZoneTestCase {
+  timeZoneId: GuxTimeZoneIdentifier;
+  expectedOutput: string;
+}
+
+describe('gux-time-zone.service', () => {
+  describe('#getLocalizedOffset', () => {
+    const cases: ZoneTestCase[] = [
+      { timeZoneId: 'Etc/GMT', expectedOutput: 'UTC+00:00' },
+      { timeZoneId: 'Etc/GMT-1', expectedOutput: 'UTC+01:00' }
+    ];
+    cases.forEach(
+      ({
+        timeZoneId,
+        expectedOutput
+      }: {
+        timeZoneId: GuxTimeZoneIdentifier;
+        expectedOutput: string;
+      }) => {
+        it(`should work as expected for "${timeZoneId}"`, async () => {
+          expect(getLocalizedOffset('UTC', timeZoneId)).toBe(expectedOutput);
+        });
+      }
+    );
+  });
+
+  describe('#shortenZone', () => {
+    [
+      { timeZone: 'Etc/GMT', expectedOutput: 'GMT' },
+      { timeZone: 'Europe/London', expectedOutput: 'London' }
+    ].forEach(({ timeZone, expectedOutput }) => {
+      it(`should work as expected for "${timeZone}"`, async () => {
+        expect(shortenZone(timeZone)).toBe(expectedOutput);
+      });
+    });
+  });
+});

--- a/packages/genesys-spark-components/src/components/beta/gux-time-zone/tests/gux-time-zone.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-zone/tests/gux-time-zone.spec.ts
@@ -1,0 +1,40 @@
+import { getLocalizedOffset, shortenZone } from '../gux-time-zone.service';
+import { GuxTimeZoneIdentifier } from '../../../../i18n/time-zone/types';
+
+interface ZoneTestCase {
+  timeZoneId: GuxTimeZoneIdentifier;
+  expectedOutput: string;
+}
+
+describe('gux-time-zone.service', () => {
+  describe('#getLocalizedOffset', () => {
+    const cases: ZoneTestCase[] = [
+      { timeZoneId: 'Etc/GMT', expectedOutput: 'UTC+00:00' },
+      { timeZoneId: 'Etc/GMT-1', expectedOutput: 'UTC+01:00' }
+    ];
+    cases.forEach(
+      ({
+        timeZoneId,
+        expectedOutput
+      }: {
+        timeZoneId: GuxTimeZoneIdentifier;
+        expectedOutput: string;
+      }) => {
+        it(`should work as expected for "${timeZoneId}"`, async () => {
+          expect(getLocalizedOffset('UTC', timeZoneId)).toBe(expectedOutput);
+        });
+      }
+    );
+  });
+
+  describe('#shortenZone', () => {
+    [
+      { timeZone: 'Etc/GMT', expectedOutput: 'GMT' },
+      { timeZone: 'Europe/London', expectedOutput: 'London' }
+    ].forEach(({ timeZone, expectedOutput }) => {
+      it(`should work as expected for "${timeZone}"`, async () => {
+        expect(shortenZone(timeZone)).toBe(expectedOutput);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This component was added to v3 but never v4 back in September 2023. There was a request to add it to v4 and I don't see any obvious reason not to but I'm open to correction. 

✅ Closes: COMUI-2956