### PR TITLE
docs(form-field-radio-group): update html file to reflect UX guidelines

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox-group/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox-group/example.html
@@ -32,13 +32,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="cherry"
-        disabled
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="cherry" />
       <label slot="label">Cherry</label>
     </gux-form-field-checkbox>
 
@@ -50,7 +44,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error messsage</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -61,7 +54,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
   </gux-form-field-checkbox-group-beta>
 </form>
@@ -80,13 +72,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="sprinkles"
-        checked
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="sprinkles" />
       <label slot="label">Sprinkles</label>
     </gux-form-field-checkbox>
 
@@ -108,7 +94,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -119,7 +104,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
   </gux-form-field-checkbox-group-beta>
 </form>
@@ -159,13 +143,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="cherry"
-        disabled
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="cherry" />
       <label slot="label">Cherry</label>
     </gux-form-field-checkbox>
 
@@ -177,7 +155,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -188,7 +165,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
   </gux-form-field-checkbox-group-beta>
 </form>
@@ -204,13 +180,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="cherry"
-        disabled
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="cherry" />
       <label slot="label">Cherry</label>
     </gux-form-field-checkbox>
 
@@ -222,7 +192,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -233,7 +202,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
     <span slot="group-error">This is an error message</span>
   </gux-form-field-checkbox-group-beta>
@@ -250,13 +218,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="cherry"
-        disabled
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="cherry" />
       <label slot="label">Cherry</label>
     </gux-form-field-checkbox>
 
@@ -268,7 +230,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -279,7 +240,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
     <span slot="group-help">This is a group help message</span>
   </gux-form-field-checkbox-group-beta>
@@ -296,13 +256,7 @@
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="topping-1"
-        value="cherry"
-        disabled
-      />
+      <input slot="input" type="checkbox" name="topping-1" value="cherry" />
       <label slot="label">Cherry</label>
     </gux-form-field-checkbox>
 
@@ -314,7 +268,6 @@
         value="strawberries"
       />
       <label slot="label">Strawberries</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-checkbox>
 
     <gux-form-field-checkbox>
@@ -325,7 +278,6 @@
         value="cookieCrumble"
       />
       <label slot="label">Cookie Crumble</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
   </gux-form-field-checkbox-group-beta>
 
@@ -342,13 +294,7 @@
       </gux-form-field-checkbox>
 
       <gux-form-field-checkbox>
-        <input
-          slot="input"
-          type="checkbox"
-          name="topping-1"
-          value="cherry"
-          disabled
-        />
+        <input slot="input" type="checkbox" name="topping-1" value="cherry" />
         <label slot="label">Cherry</label>
       </gux-form-field-checkbox>
 
@@ -360,7 +306,6 @@
           value="strawberries"
         />
         <label slot="label">Strawberries</label>
-        <span slot="error">This is an error message</span>
       </gux-form-field-checkbox>
 
       <gux-form-field-checkbox>
@@ -371,7 +316,6 @@
           value="cookieCrumble"
         />
         <label slot="label">Cookie Crumble</label>
-        <span slot="help">This is a help message</span>
       </gux-form-field-checkbox>
     </gux-form-field-checkbox-group-beta>
   </form>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
@@ -3,77 +3,69 @@
 <p>
   slot a input[type=checkbox] element into a gux-form-field-checkbox element
 </p>
+<p>
+  Recommended to use within the `gux-form-field-checkbox-group-beta` component.
+</p>
 
-<h2>Example</h2>
 <form onchange="notify(event)" oninput="notify(event)">
-  <fieldset>
-    <legend>Food</legend>
+  <h2>Example 1</h2>
+  <gux-form-field-checkbox>
+    <input slot="input" type="checkbox" name="food-1[]" value="pizza" />
+    <label slot="label">Pizza</label>
+  </gux-form-field-checkbox>
+  <gux-button-slot style="margin-top: 10px">
+    <button
+      type="button"
+      onclick="(function () {
+        const field = document.querySelector(`input[name='food-1[]'][value='pizza']`)
+        field.checked = !field.checked;
+      })()"
+    >
+      Toggle Pizza field
+    </button>
+  </gux-button-slot>
+  <h2>Example 2 - Initial Checked State</h2>
+  <gux-form-field-checkbox>
+    <input slot="input" type="checkbox" name="food-1[]" value="pasta" checked />
+    <label slot="label">Pasta</label>
+  </gux-form-field-checkbox>
+  <h2>Example 3 - Indeterminate State</h2>
+  <gux-form-field-checkbox>
+    <input slot="input" type="checkbox" name="food-1[]" value="hamburger" />
+    <label slot="label">Hamburger</label>
+  </gux-form-field-checkbox>
 
-    <gux-form-field-checkbox>
-      <input slot="input" type="checkbox" name="food-1[]" value="pizza" />
-      <label slot="label">Pizza</label>
-    </gux-form-field-checkbox>
-
-    <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="food-1[]"
-        value="pasta"
-        checked
-      />
-      <label slot="label">Pasta</label>
-    </gux-form-field-checkbox>
-
-    <gux-form-field-checkbox>
-      <input slot="input" type="checkbox" name="food-1[]" value="hamburger" />
-      <label slot="label">Hamburger</label>
-    </gux-form-field-checkbox>
-
-    <gux-form-field-checkbox>
-      <input
-        slot="input"
-        type="checkbox"
-        name="food-1[]"
-        value="sandwich"
-        disabled
-      />
-      <label slot="label">Sandwich</label>
-    </gux-form-field-checkbox>
-
-    <gux-form-field-checkbox>
-      <input slot="input" type="checkbox" name="food-1[]" value="sushi" />
-      <label slot="label">Sushi</label>
-      <span slot="error">Subject to availability</span>
-    </gux-form-field-checkbox>
-
-    <gux-form-field-checkbox>
-      <input slot="input" type="checkbox" name="food-1[]" value="spaghetti" />
-      <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
-    </gux-form-field-checkbox>
-  </fieldset>
+  <gux-button-slot style="margin-top: 10px">
+    <button
+      type="button"
+      onclick="(function () {
+        document.querySelector(`input[name='food-1[]'][value='hamburger']`).indeterminate = true;
+      })()"
+    >
+      Set Hamburger field to indeterminate
+    </button>
+  </gux-button-slot>
+  <h2>Example 4 - Disabled</h2>
+  <gux-form-field-checkbox>
+    <input
+      slot="input"
+      type="checkbox"
+      name="food-1[]"
+      value="sandwich"
+      disabled
+    />
+    <label slot="label">Sandwich</label>
+  </gux-form-field-checkbox>
+  <h2>Example - Error Text</h2>
+  <gux-form-field-checkbox>
+    <input slot="input" type="checkbox" name="food-1[]" value="sushi" />
+    <label slot="label">Sushi</label>
+    <span slot="error">Subject to availability</span>
+  </gux-form-field-checkbox>
+  <h2>Example - Help Text</h2>
+  <gux-form-field-checkbox>
+    <input slot="input" type="checkbox" name="food-1[]" value="spaghetti" />
+    <label slot="label">Spaghetti</label>
+    <span slot="help">This is a help message</span>
+  </gux-form-field-checkbox>
 </form>
-
-<gux-button-slot>
-  <button
-    type="button"
-    onclick="(function () {
-      document.querySelector(`input[name='food-1[]'][value='hamburger']`).indeterminate = true;
-    })()"
-  >
-    Set Hamburger field to indeterminate
-  </button>
-</gux-button-slot>
-
-<gux-button-slot>
-  <button
-    type="button"
-    onclick="(function () {
-      const field = document.querySelector(`input[name='food-1[]'][value='pizza']`)
-      field.checked = !field.checked;
-    })()"
-  >
-    Toggle Pizza field
-  </button>
-</gux-button-slot>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
@@ -8,7 +8,7 @@
 </p>
 
 <form onchange="notify(event)" oninput="notify(event)">
-  <h2>Example 1</h2>
+  <h2>Example 1 - Default</h2>
   <gux-form-field-checkbox>
     <input slot="input" type="checkbox" name="food-1[]" value="pizza" />
     <label slot="label">Pizza</label>
@@ -56,13 +56,13 @@
     />
     <label slot="label">Sandwich</label>
   </gux-form-field-checkbox>
-  <h2>Example - Error Text</h2>
+  <h2>Example 5 - Error Message</h2>
   <gux-form-field-checkbox>
     <input slot="input" type="checkbox" name="food-1[]" value="sushi" />
     <label slot="label">Sushi</label>
     <span slot="error">Subject to availability</span>
   </gux-form-field-checkbox>
-  <h2>Example - Help Text</h2>
+  <h2>Example 6 - Help Text</h2>
   <gux-form-field-checkbox>
     <input slot="input" type="checkbox" name="food-1[]" value="spaghetti" />
     <label slot="label">Spaghetti</label>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
@@ -61,7 +61,7 @@
       <input slot="input" type="radio" name="food-1" value="spaghetti" />
       <label slot="label">Spaghetti</label>
     </gux-form-field-radio>
-    <span slot="group-error">Subject to availibility</span>
+    <span slot="group-error">This is an error message</span>
   </gux-form-field-radio-group-beta>
 </form>
 

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio-group/example.html
@@ -21,26 +21,18 @@
     </gux-form-field-radio>
 
     <gux-form-field-radio>
-      <input
-        slot="input"
-        type="radio"
-        name="food-1"
-        value="sandwich"
-        disabled
-      />
+      <input slot="input" type="radio" name="food-1" value="sandwich" />
       <label slot="label">Sandwich</label>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="sushi" />
       <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="spaghetti" />
       <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-radio>
   </gux-form-field-radio-group-beta>
 </form>
@@ -56,26 +48,18 @@
     </gux-form-field-radio>
 
     <gux-form-field-radio>
-      <input
-        slot="input"
-        type="radio"
-        name="food-1"
-        value="sandwich"
-        disabled
-      />
+      <input slot="input" type="radio" name="food-1" value="sandwich" />
       <label slot="label">Sandwich</label>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="sushi" />
       <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="spaghetti" />
       <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-radio>
     <span slot="group-error">Subject to availibility</span>
   </gux-form-field-radio-group-beta>
@@ -92,26 +76,18 @@
     </gux-form-field-radio>
 
     <gux-form-field-radio>
-      <input
-        slot="input"
-        type="radio"
-        name="food-1"
-        value="sandwich"
-        disabled
-      />
+      <input slot="input" type="radio" name="food-1" value="sandwich" />
       <label slot="label">Sandwich</label>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="sushi" />
       <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="spaghetti" />
       <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-radio>
     <span slot="group-help">This is a group help message</span>
   </gux-form-field-radio-group-beta>
@@ -128,26 +104,18 @@
     </gux-form-field-radio>
 
     <gux-form-field-radio>
-      <input
-        slot="input"
-        type="radio"
-        name="food-1"
-        value="sandwich"
-        disabled
-      />
+      <input slot="input" type="radio" name="food-1" value="sandwich" />
       <label slot="label">Sandwich</label>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="sushi" />
       <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
     </gux-form-field-radio>
 
     <gux-form-field-radio>
       <input slot="input" type="radio" name="food-1" value="spaghetti" />
       <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-radio>
   </gux-form-field-radio-group-beta>
 
@@ -164,26 +132,18 @@
       </gux-form-field-radio>
 
       <gux-form-field-radio>
-        <input
-          slot="input"
-          type="radio"
-          name="food-1"
-          value="sandwich"
-          disabled
-        />
+        <input slot="input" type="radio" name="food-1" value="sandwich" />
         <label slot="label">Sandwich</label>
       </gux-form-field-radio>
 
       <gux-form-field-radio>
         <input slot="input" type="radio" name="food-1" value="sushi" />
         <label slot="label">Sushi</label>
-        <span slot="error">Subject to availibility</span>
       </gux-form-field-radio>
 
       <gux-form-field-radio>
         <input slot="input" type="radio" name="food-1" value="spaghetti" />
         <label slot="label">Spaghetti</label>
-        <span slot="help">This is a help message</span>
       </gux-form-field-radio>
     </gux-form-field-radio-group-beta>
   </form>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/example.html
@@ -1,48 +1,42 @@
 <h1>gux-form-field-radio</h1>
 
 <p>slot a input[type=radio] element into a gux-form-field-radio element</p>
+<p>Recommended to use within the `gux-form-field-radio-group-beta` component</p>
 
-<h2>Example</h2>
 <form onchange="notify(event)" oninput="notify(event)">
-  <fieldset>
-    <legend>Food</legend>
+  <h2>Example 1 - Default</h2>
 
-    <gux-form-field-radio>
-      <input slot="input" type="radio" name="food-1" value="pizza" />
-      <label slot="label">Pizza</label>
-    </gux-form-field-radio>
+  <gux-form-field-radio>
+    <input slot="input" type="radio" name="food-1" value="pizza" />
+    <label slot="label">Pizza</label>
+  </gux-form-field-radio>
 
-    <gux-form-field-radio>
-      <input slot="input" type="radio" name="food-1" value="pasta" checked />
-      <label slot="label">Pasta</label>
-    </gux-form-field-radio>
+  <h2>Example 2 - Initial Checked State</h2>
 
-    <gux-form-field-radio>
-      <input slot="input" type="radio" name="food-1" value="hamburger" />
-      <label slot="label">Hamburger</label>
-    </gux-form-field-radio>
+  <gux-form-field-radio>
+    <input slot="input" type="radio" name="food-1" value="pasta" checked />
+    <label slot="label">Pasta</label>
+  </gux-form-field-radio>
 
-    <gux-form-field-radio>
-      <input
-        slot="input"
-        type="radio"
-        name="food-1"
-        value="sandwich"
-        disabled
-      />
-      <label slot="label">Sandwich</label>
-    </gux-form-field-radio>
+  <h2>Example 3 - Disabled</h2>
 
-    <gux-form-field-radio>
-      <input slot="input" type="radio" name="food-1" value="sushi" />
-      <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
-    </gux-form-field-radio>
+  <gux-form-field-radio>
+    <input slot="input" type="radio" name="food-1" value="sandwich" disabled />
+    <label slot="label">Sandwich</label>
+  </gux-form-field-radio>
 
-    <gux-form-field-radio>
-      <input slot="input" type="radio" name="food-1" value="spaghetti" />
-      <label slot="label">Spaghetti</label>
-      <span slot="help">This is a help message</span>
-    </gux-form-field-radio>
-  </fieldset>
+  <h2>Example 4 - Error Message</h2>
+
+  <gux-form-field-radio>
+    <input slot="input" type="radio" name="food-1" value="sushi" />
+    <label slot="label">Sushi</label>
+    <span slot="error">Subject to availibility</span>
+  </gux-form-field-radio>
+
+  <h2>Example 5 - Help Text</h2>
+  <gux-form-field-radio>
+    <input slot="input" type="radio" name="food-1" value="spaghetti" />
+    <label slot="label">Spaghetti</label>
+    <span slot="help">This is a help message</span>
+  </gux-form-field-radio>
 </form>


### PR DESCRIPTION
Update the example html files to match UX usage guidelines for the `form-field-checkbox-group-beta` and the `form-field-radio-group-beta` components.

**Question**: Is it enough to just update the example file to match UX guidelines? Or should we add `log warn` for combinations of uses that are not part of the UX guidelines? 

For example, a UX guideline is that the Error text slot should override the Help text slot. Should we add logic to the component to constrain users to this usage guideline?

It is my inclination to not impose strict usage guidelines within the component itself, instead we just update the examples so that users follow the best practices.