### PR TITLE
feat(cta group): make responsive and allow buttons to truncate if necessary

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-cta-group/gux-cta-group.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-cta-group/gux-cta-group.scss
@@ -1,9 +1,21 @@
+:host {
+  display: block;
+}
+
 .gux-cta-group {
   display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
   gap: var(--gse-ui-ctaGroup-gap);
+  justify-content: start;
 
   &.gux-end-align {
     flex-direction: row-reverse;
-    align-items: flex-end;
+    justify-content: end;
+  }
+
+  ::slotted(gux-button) {
+    flex: 0 1 auto;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
You can now apply a width to the cta group & the buttons will truncate if necessary.