### PR TITLE
style(listbox): remove default box-shadow style

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
@@ -191,6 +191,9 @@
 
 ::slotted(gux-listbox) {
   outline: none;
+  box-shadow: var(--gse-ui-menu-boxShadow-x) var(--gse-ui-menu-boxShadow-y)
+    var(--gse-ui-menu-boxShadow-blur) var(--gse-ui-menu-boxShadow-spread)
+    var(--gse-ui-menu-boxShadow-color);
 }
 
 // Selected option styles

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.scss
@@ -10,9 +10,6 @@
     var(--gse-ui-menu-border-color);
   border-radius: var(--gse-ui-menu-borderRadius);
   outline: none;
-  box-shadow: var(--gse-ui-menu-boxShadow-x) var(--gse-ui-menu-boxShadow-y)
-    var(--gse-ui-menu-boxShadow-blur) var(--gse-ui-menu-boxShadow-spread)
-    var(--gse-ui-menu-boxShadow-color);
 }
 
 :host(:focus-visible) {


### PR DESCRIPTION
remove default box-shadow style, should only be applied to the `gux-dropdown` use case as confirmed by UX.

✅ Closes: COMUI-3012

https://inindca.atlassian.net/browse/COMUI-3012