### PR TITLE
style(modal): dynamic gux-modal footer buttons getting cut off 

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
@@ -35,7 +35,6 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
     .gux-modal-container {
       display: flex;
       flex-direction: column;
-      padding-top: var(--gse-ui-modal-padding);
       padding-bottom: var(--gse-ui-modal-padding);
 
       &.gux-small {
@@ -63,6 +62,7 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
       }
 
       .gux-modal-header {
+        padding-top: var(--gse-ui-modal-padding);
         padding-right: var(--gse-ui-modal-padding);
         padding-left: var(--gse-ui-modal-padding);
         margin: 0;

--- a/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-modal/gux-modal.scss
@@ -35,7 +35,6 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
     .gux-modal-container {
       display: flex;
       flex-direction: column;
-      padding-bottom: var(--gse-ui-modal-padding);
 
       &.gux-small {
         width: var(--gse-ui-modal-small-width);
@@ -86,6 +85,7 @@ slot[name='start-align-buttons']::slotted(:not(button, gux-button-slot)) {
         display: flex;
         justify-content: space-between;
         padding-right: var(--gse-ui-modal-padding);
+        padding-bottom: var(--gse-ui-modal-padding);
         padding-left: var(--gse-ui-modal-padding);
         margin-top: var(--gse-ui-modal-gap);
 


### PR DESCRIPTION
Apply padding-top to modal-header instead of container. The ticket also mentions that the `dialog` element has scrollbars but these were removed in a previous PR.

✅ Closes: COMUI-2998