### PR TITLE
fix(dropdown): filterable dropdown/multi disabled state not updating correctly

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
@@ -22,6 +22,7 @@
 .gux-disabled {
   &.gux-target-container-collapsed .gux-field-button,
   &.gux-target-container-expanded {
+    user-select: none;
     border: var(--gse-ui-formControl-input-disabled-border-width)
       var(--gse-ui-formControl-input-disabled-border-style)
       var(--gse-ui-formControl-input-disabled-border-color);

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
@@ -152,6 +152,13 @@ export class GuxDropdownMulti {
     }
   }
 
+  @Watch('disabled')
+  watchDisabled(disabled: boolean) {
+    if (disabled) {
+      this.expanded = false;
+    }
+  }
+
   @Watch('value')
   watchValue(newValue: string) {
     this.validateValue(newValue, this.listboxElement);
@@ -526,6 +533,7 @@ export class GuxDropdownMulti {
                   onInput={this.filterInput.bind(this)}
                   onKeyDown={this.filterKeydown.bind(this)}
                   onKeyUp={this.filterKeyup.bind(this)}
+                  disabled={this.disabled}
                 ></input>
               </div>
             </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
@@ -46,6 +46,7 @@
 .gux-disabled {
   &.gux-target-container-collapsed .gux-field-button,
   &.gux-target-container-expanded {
+    user-select: none;
     border: var(--gse-ui-formControl-input-disabled-border-width)
       var(--gse-ui-formControl-input-disabled-border-style)
       var(--gse-ui-formControl-input-disabled-border-color);

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -110,6 +110,13 @@ export class GuxDropdown {
     this.guxfilter.emit(filter);
   }
 
+  @Watch('disabled')
+  watchDisabled(disabled: boolean) {
+    if (disabled) {
+      this.expanded = false;
+    }
+  }
+
   @Listen('keydown')
   onKeydown(event: KeyboardEvent): void {
     switch (event.key) {
@@ -484,6 +491,7 @@ export class GuxDropdown {
                   onInput={this.filterInput.bind(this)}
                   onKeyDown={this.filterKeydown.bind(this)}
                   onKeyUp={this.filterKeyup.bind(this)}
+                  disabled={this.disabled}
                 ></input>
               </div>
             </div>


### PR DESCRIPTION
**Note**
You can reproduce this issue by setting the `disabled` attribute on the dropdown using a `setTimeout`.  You will need to remove my changes to see this.

Added disabled checks to dropdown and dropdown multi

[✅ Closes: COMUI-3052](https://inindca.atlassian.net/browse/COMUI-3052)