### PR TITLE
fix(dropdown): dropdown is now disabled when loading non-filterable list

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
@@ -610,7 +610,7 @@ export class GuxDropdownMulti {
       <div class="gux-dropdown-container">
         <gux-popup
           expanded={this.expanded && (!this.loading || this.isFilterable())}
-          disabled={this.disabled}
+          disabled={this.disabled || (this.loading && !this.isFilterable())}
           exceedTargetWidth={this.exceedTargetWidth}
         >
           {this.renderTarget()}

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -567,7 +567,7 @@ export class GuxDropdown {
     return (
       <gux-popup
         expanded={this.expanded && (!this.loading || this.isFilterable())}
-        disabled={this.disabled}
+        disabled={this.disabled || (this.loading && !this.isFilterable())}
         exceedTargetWidth={this.exceedTargetWidth}
       >
         {this.renderTarget()}


### PR DESCRIPTION
**Note**

I went with the same pattern we use across different components like `gux-toggle` that when the component is `loading` it should be in a disabled state so the user cannot interact with it.

I did not apply this change to the `filterable` dropdown as I think it did not make sense to but I am open to opinions. 

I will loop UX in as-well to get some of there input on what is the expected behaviour.

[✅ Closes: COMUI-3063](https://inindca.atlassian.net/browse/COMUI-3063)