### PR TITLE
fix(table-toolbar): change mixin to not create a stacking context

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.scss
@@ -1,19 +1,15 @@
 @mixin gux-toolbar-prevent-initial-flicker-workaround {
-  opacity: 0;
-  animation-name: show-toolbar;
-  animation-delay: 0.5s;
-  animation-fill-mode: forwards;
+  visibility: hidden;
+  transition: visibility 0s 0.5s; /* Delay visibility of toolbar for 0.5s */
 
   @keyframes show-toolbar {
     to {
-      opacity: 1;
+      visibility: visible;
     }
   }
 }
 
 :host {
-  position: relative;
-  z-index: var(--gse-semantic-zIndex-sticky);
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
The `gux-toolbar-flicker-workaround` mixin was creating an unnecessary stacking context so I switched to use visibility instead with the same delay to prevent the flicker and removed the `z-index` also which will not be needed on the toolbar anymore. I probably should have chose `visibility` over `opacity` when resolving this issue (https://github.com/MyPureCloud/genesys-spark/pull/505)
[✅ Closes: COMUI-3070](https://inindca.atlassian.net/browse/COMUI-3070)