### PR TITLE
chore(popover): Using gux-cta-group to group content buttons

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/example.html
@@ -11,17 +11,17 @@
       <span slot="title">Title</span>
       <div class="popover-content-wrapper">
         <div>Popover Content</div>
-        <div class="popover-content">
-          <gux-button accent="ghost" onclick="notify(event)">
-            Action 3
-          </gux-button>
-          <gux-button accent="secondary" onclick="notify(event)">
-            Action 2
-          </gux-button>
-          <gux-button accent="primary" onclick="notify(event)">
-            Action 1
-          </gux-button>
-        </div>
+        <gux-cta-group align="end">
+          <gux-button slot="primary" onclick="notify(event)"
+            >Action 3</gux-button
+          >
+          <gux-button slot="secondary" onclick="notify(event)"
+            >Action 2</gux-button
+          >
+          <gux-button slot="dismiss" onclick="notify(event)"
+            >Action 1</gux-button
+          >
+        </gux-cta-group>
       </div>
     </gux-popover>
   </div>


### PR DESCRIPTION
✅ Closes: COMUI-3081

I asked UX if they could take a look at the time machine branch in this PR and Monse said the changes looked good. I told her that the changes I made were only in the example.html file for the component so the consumers of gux-popup would have to remember to use the gux-cta-group component in gux-popover's slotted content if they wanted multiple gux-button instances grouped.