### PR TITLE
fix(visualization): don't show vega-lite actions menu by default in g…

### DIFF
--- a/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.tsx
+++ b/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.tsx
@@ -40,7 +40,7 @@ export class GuxVisualization {
   };
 
   private defaultEmbedOptions: EmbedOptions = {
-    actions: true,
+    actions: false,
     renderer: 'svg'
   };
 


### PR DESCRIPTION
…ux-visualization

✅ Closes: COMUI-3091

Fix for accidental change. Gux-visualization should default to not showing the vega-lite actions menu that allows users to view the visualization spec in the vega online editor.