### PR TITLE
feat(copy-to-clipboard): detect overflow in tooltip position

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.tsx
@@ -24,6 +24,7 @@ import { randomHTMLId } from '@utils/dom/random-html-id';
 import { trackComponent } from '@utils/tracking/usage';
 import { afterNextRender } from '@utils/dom/after-next-render';
 import { GuxTooltipAccent } from '../gux-tooltip-beta/gux-tooltip-types';
+import { overflowDetection } from '@utils/dom/overflow-detection';
 
 /**
  * @slot content - Slot for content
@@ -132,7 +133,13 @@ export class GuxTooltipBase {
   }
 
   private updatePosition(): void {
-    const middleware = [offset(16), flip(), shift(), hide()];
+    const middleware = [
+      offset(16),
+      flip(),
+      shift(),
+      hide(),
+      overflowDetection()
+    ];
 
     void computePosition(this.forElement, this.root, {
       placement: this.placement,

--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -25,6 +25,7 @@ import { trackComponent } from '@utils/tracking/usage';
 import { findElementById } from '@utils/dom/find-element-by-id';
 import { afterNextRender } from '@utils/dom/after-next-render';
 import { GuxTooltipAccent } from './gux-tooltip-types';
+import { overflowDetection } from '@utils/dom/overflow-detection';
 
 /**
  * @slot content - Slot for content
@@ -117,7 +118,13 @@ export class GuxTooltip {
   }
 
   private updatePosition(): void {
-    const middleware = [offset(16), flip(), shift(), hide()];
+    const middleware = [
+      offset(16),
+      flip(),
+      shift(),
+      hide(),
+      overflowDetection()
+    ];
 
     void computePosition(this.forElement, this.root, {
       placement: this.placement,

--- a/packages/genesys-spark-components/src/utils/dom/overflow-detection.ts
+++ b/packages/genesys-spark-components/src/utils/dom/overflow-detection.ts
@@ -1,0 +1,27 @@
+import { detectOverflow } from '@floating-ui/dom';
+
+export function overflowDetection() {
+  return {
+    name: 'overflowDetection',
+    async fn(state) {
+      const overflowData = await detectOverflow(state, {
+        boundary: 'clippingAncestors',
+        elementContext: 'reference'
+      });
+
+      if (state.placement.includes('bottom') && overflowData.bottom > 0) {
+        return {
+          y: state.y - overflowData.bottom
+        };
+      }
+
+      if (state.placement.includes('top') && overflowData.top > 0) {
+        return {
+          y: state.y + overflowData.top
+        };
+      }
+
+      return {};
+    }
+  };
+}


### PR DESCRIPTION
✅ Closes: COMUI-3077

###  Examples for testing
####  copy-to-clipboard
```
<div
  style="
    width: 300px;
    max-height: 200px;
    overflow: auto;
    border: blue 1px solid;
  "
>
  <gux-copy-to-clipboard>
    <div slot="content">
      cing elit. Ut mollis serus posuere a. Proin pel cing elit. Ut mollis serus
      posuere a. Proin pel cing elit. Ut mollis serus posuere a. Proin pel cing
      elit. Ut mollis serus posuere a. Proin pel cing elit. Ut mollis serus
      posuere a. Proin pel cing elit. Ut mollis serus posuere a. Proin pel cing
      elit. Ut mollis serus posuere a. Proin pel cing elit. Ut mollis serus
      posuere a. Proin pellentesque suscipit erat, id maximus lorem consectetur
      nec. Sed vel viverra.
    </div>
  </gux-copy-to-clipboard>
</div>
```
#### gux-tooltip-beta
```
<div
  style="
    width: 300px;
    max-height: 100px;
    overflow: auto;
    border: blue 1px solid;
  "
>
  <p style="margin: 0; padding: 12px 0;">
    By default, the tooltip will be displayed when hovering over the parent
    node. Default positioning is beneath the node. The tooltip is not restricted
    by the parent's overflow style. If the text is sufficiently long, it will
    wrap into multiple lines.

    By default, the tooltip will be displayed when hovering over the parent
    node. Default positioning is beneath the node. The tooltip is not restricted
    by the parent's overflow style. If the text is sufficiently long, it will
    wrap into multiple lines.
    <gux-tooltip-beta><span slot="content">More paragraph information</span></gux-tooltip-beta>
  </p>
```
