### PR TITLE
fix(gux-visualization): fix memory leak in gux-visualization

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-visualization/gux-visualization.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-visualization/gux-visualization.tsx
@@ -9,7 +9,7 @@ import {
   Event,
   EventEmitter
 } from '@stencil/core';
-import embed, { EmbedOptions, VisualizationSpec } from 'vega-embed';
+import embed, { EmbedOptions, VisualizationSpec, Result } from 'vega-embed';
 import { Spec as VgSpec } from 'vega';
 
 import { getDesiredLocale } from '../../../i18n';
@@ -30,6 +30,8 @@ export class GuxVisualization {
     actions: false,
     renderer: 'svg'
   };
+
+  private vegaEmbedResult?: Result;
 
   @Event()
   chartComponentReady: EventEmitter;
@@ -83,10 +85,19 @@ export class GuxVisualization {
         patchOption
       )
     ).then(result => {
+      // Finalize any previous embed, which will remove event listeners and other items to prevent memory leaks
+      this.vegaEmbedResult?.finalize();
+      this.vegaEmbedResult = result;
+
       result.view.addSignalListener('chartClick', (name, value) =>
         this.handleChartClick(name, value)
       );
     });
+  }
+
+  disconnectedCallback(): void {
+    this.vegaEmbedResult?.finalize();
+    this.vegaEmbedResult = undefined;
   }
 
   componentDidLoad() {


### PR DESCRIPTION
Fixes a memory leak in gux-visualization by calling the vega-embed finalize function to remove event listeners and other items.