### PR TITLE
fix(visualization): add height to chart container

### DIFF
--- a/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.scss
+++ b/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.scss
@@ -4,4 +4,5 @@
 
 .gux-chart-container {
   width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
**Note**

The reported also suggested adding the `::part` pseudo element to the `.gux-chart-container` div so they could add additional styles but I am not sure if this is a good idea.

[✅ Closes: COMUI-3166](https://inindca.atlassian.net/browse/COMUI-3166)