### PR TITLE
style(other): Update color of form-field-input-clear-button

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/helper-components/gux-form-field-input-clear-button/gux-form-field-input-clear-button.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/helper-components/gux-form-field-input-clear-button/gux-form-field-input-clear-button.scss
@@ -1,7 +1,7 @@
 button {
   display: flex;
   padding: 0;
-  color: var(--gse-ui-formControl-input-inputIcon-defaultColor);
+  color: var(--gse-ui-formControl-input-inputIcon-iconEndColor);
   background: transparent;
   border: none;
   border-radius: var(--gse-ui-formControl-input-borderRadius);


### PR DESCRIPTION
Update the `color` of the `button` element to be : `--gse-ui-formControl-input-inputIcon-iconEndColor`

One thing I noticed was that the token values are different to figma. In figma the tokens value is `#6A6D75` whereas in the repo it is `626e84`

I was just wondering what we should we do in this scenario should I just update the token value myself ?

[✅ Closes: COMUI-3176](https://inindca.atlassian.net/browse/COMUI-3176)