### PR TITLE
fix(tabs): check if tab-list is set on initialisation

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tabs/gux-tabs.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tabs/gux-tabs.tsx
@@ -103,8 +103,8 @@ export class GuxTabs {
       this.activeTab = panels[0].tabId;
     }
 
-    void tabList.guxSetActive(this.activeTab);
-    panels.forEach(
+    void tabList?.guxSetActive(this.activeTab);
+    panels?.forEach(
       panel => void panel.guxSetActive(panel.tabId === this.activeTab)
     );
   }


### PR DESCRIPTION
**Note**

From what I could tell from the error and after inspecting the teams repository is that its an initialisation issue related to the `gux-tab-list`.  Sometimes the error will appear and other times it wont. As described in the ticket the tabs work as expected but its just the error that appears intermittently. This fix just adds a chaining operator to the`tabList` and `panel` to ensure no console error is emitted.

[✅ Closes: COMUI-3183](https://inindca.atlassian.net/browse/COMUI-3183)