### PR TITLE
fix(table-toolbar): always show label when in the condensed display

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
@@ -1,4 +1,6 @@
 import { Component, Element, JSX, h, Listen, Prop } from '@stencil/core';
+import { getClosestElement } from 'genesys-spark-utils/get-closest-element';
+
 import { trackComponent } from '@utils/tracking/usage';
 import { GuxTableToolbarActionAccent } from '../gux-table-toolbar-action-accents.types';
 import { getSlotTextContent } from '@utils/dom/get-slot-text-content';
@@ -33,8 +35,19 @@ export class GuxTableToolbarCustomAction {
     }
   }
 
+  private hideText(): boolean {
+    const parent = getClosestElement(
+      this.root,
+      'gux-table-toolbar'
+    ) as HTMLGuxTableToolbarElement;
+    const nonCondensedParentLayout =
+      parent?.getAttribute('gs-layout') !== 'condensed';
+
+    return this.iconOnly && nonCondensedParentLayout;
+  }
+
   private renderTooltip(): JSX.Element {
-    if (this.iconOnly) {
+    if (this.hideText()) {
       return (
         <gux-tooltip>
           <div slot="content">{getSlotTextContent(this.root, 'text')}</div>
@@ -52,7 +65,7 @@ export class GuxTableToolbarCustomAction {
       <gux-button-slot accent={this.accent}>
         <button disabled={this.disabled} type="button" class="gux-action-title">
           <slot name="icon" />
-          <span class={{ 'gux-sr-only': this.iconOnly }}>
+          <span class={{ 'gux-sr-only': this.hideText() }}>
             <slot name="text" />
           </span>
         </button>

--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.tsx
@@ -259,7 +259,11 @@ export class GuxTableToolbar {
 
   render(): JSX.Element {
     return (
-      <Host role="toolbar" aria-orientation="horizontal">
+      <Host
+        role="toolbar"
+        aria-orientation="horizontal"
+        gs-layout={this.displayedLayout}
+      >
         <div class="search-filter-container">
           <slot name="search-and-filter"></slot>
         </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gux-table-toolbar #render should render table toolbar as expected 1`] = `
-<gux-table-toolbar aria-orientation="horizontal" role="toolbar">
+<gux-table-toolbar aria-orientation="horizontal" gs-layout="full" role="toolbar">
   <template shadowrootmode="open">
     <div class="search-filter-container">
       <slot name="search-and-filter"></slot>


### PR DESCRIPTION
always show label when in the condensed display

✅ Closes: COMUI-3213