### PR TITLE
BACKPORT: fix(table): updating select all status when row removed from dom

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-table/gux-table.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-table/gux-table.tsx
@@ -42,9 +42,11 @@ export class GuxTable {
   root: HTMLElement;
 
   private resizeObserver: ResizeObserver;
-  private slotObserver: MutationObserver = new MutationObserver(() =>
-    forceUpdate(this)
-  );
+  private slotObserver: MutationObserver = new MutationObserver(() => {
+    forceUpdate(this);
+    this.prepareSelectableRows();
+  });
+
   private i18n: GetI18nValue;
   private columnResizeState: GuxTableColumnResizeState | null;
   private tableId: string = randomHTMLId('gux-table');


### PR DESCRIPTION
The table select all status will now automatically update if a row is removed from the dom.