### PR TITLE
feat: override CDN URL via assetsUrl option to registerSparkComponents

### DIFF
--- a/packages/genesys-spark-components/stencil.config.ts
+++ b/packages/genesys-spark-components/stencil.config.ts
@@ -1,4 +1,5 @@
 import { Config } from '@stencil/core';
+import { Credentials } from '@stencil/core/internal';
 import { sass } from '@stencil/sass';
 import copy from 'rollup-plugin-copy';
 import generateMetadata from './scripts/generate-component-data';
@@ -8,6 +9,16 @@ const testConsoleReporter =
   process.env.DEFAULT_TEST_REPORTER === 'true'
     ? 'default'
     : ['jest-silent-reporter', { useDots: true }];
+
+// Optionally host the dev server with https if a cert and key are provided via env variables, e.g.
+// for running local dev build within a https app using assetsUrl option of registerSparkComponents.
+let https: Credentials | undefined = undefined;
+if (process.env.SPARK_HTTPS_CERT && process.env.SPARK_HTTPS_KEY) {
+  https = {
+    key: process.env.SPARK_HTTPS_KEY,
+    cert: process.env.SPARK_HTTPS_CERT
+  };
+}
 
 export const config: Config = {
   namespace: 'genesys-webcomponents',
@@ -81,6 +92,7 @@ export const config: Config = {
     experimentalImportInjection: true
   },
   devServer: {
-    port: 3733
+    port: 3733,
+    https
   }
 };

--- a/packages/genesys-spark/src/index.ts
+++ b/packages/genesys-spark/src/index.ts
@@ -13,6 +13,11 @@ const COMPONENT_ASSET_PREFIX = '__COMPONENT_ASSET_PREFIX__';
 const CHART_COMPONENT_ASSET_PREFIX = '__CHART_COMPONENT_ASSET_PREFIX__';
 
 interface registerOptions {
+  /**
+   * Optional base URL to use for component assets like JS and CSS (i.e. where dist/genesys-webcomponents is hosted).
+   * This is meant for testing. In production, assets should be loaded from the default CDN location.
+   */
+  assetsUrl?: string;
   theme?: 'flare' | 'legacy';
 }
 
@@ -51,8 +56,17 @@ export function registerSparkComponents(opts?: registerOptions): Promise<void> {
       : 'genesys-webcomponents.css';
 
   const assetsOrigin = getComponentAssetsOrigin();
-  const SCRIPT_SRC = `${assetsOrigin}${COMPONENT_ASSET_PREFIX}${SCRIPT_PATH}`;
-  const STYLE_HREF = `${assetsOrigin}${COMPONENT_ASSET_PREFIX}${STYLE_PATH}`;
+  let assetsUrl = `${assetsOrigin}${COMPONENT_ASSET_PREFIX}`;
+
+  if (opts?.assetsUrl) {
+    assetsUrl = opts.assetsUrl;
+    if (!assetsUrl.endsWith('/')) {
+      assetsUrl += '/';
+    }
+  }
+
+  const SCRIPT_SRC = `${assetsUrl}${SCRIPT_PATH}`;
+  const STYLE_HREF = `${assetsUrl}${STYLE_PATH}`;
 
   return Promise.all([
     checkAndLoadScript(SCRIPT_SRC),


### PR DESCRIPTION
Add new `assetsUrl` field to registerOptions to allow overriding the CDN URL when calling registerSparkComponents().

This makes it easier to test a local build of Spark components in an app without making major hacks to how Spark components are registered.

https://inindca.atlassian.net/browse/COMUI-3244