### PR TITLE
fix(toggle): screen reader label set to checked label

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle-slider/gux-toggle-slider.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle-slider/gux-toggle-slider.tsx
@@ -24,11 +24,7 @@ export class GuxToggleSlider {
   errorId: string = '';
 
   componentDidLoad(): void {
-    if (this.labelId) {
-      this.checkboxElement?.setAttribute('aria-labelledby', this.labelId);
-    } else {
-      this.checkboxElement?.setAttribute('aria-label', this.guxAriaLabel);
-    }
+    this.checkboxElement?.setAttribute('aria-label', this.guxAriaLabel);
     if (this.errorId) {
       this.checkboxElement?.setAttribute('aria-describedby', this.errorId);
     }

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle.tsx
@@ -90,6 +90,7 @@ export class GuxToggle {
   private getAriaLabel(): string {
     return (
       this.root.getAttribute('aria-label') ||
+      this.checkedLabel ||
       this.root.title ||
       this.i18n('defaultAriaLabel')
     );

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.spec.ts.snap
@@ -69,7 +69,7 @@ exports[`gux-toggle #render should render component as expected (4) 1`] = `
     <div class="gux-toggle-container">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="false" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="false" aria-disabled="false" aria-label="On" class="gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
@@ -107,7 +107,7 @@ exports[`gux-toggle #render should render component as expected (5) 1`] = `
     <div class="gux-toggle-container">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="true" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="true" aria-disabled="false" aria-label="on" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
@@ -145,7 +145,7 @@ exports[`gux-toggle #render should render component as expected (6) 1`] = `
     <div class="gux-toggle-container gux-toggle-label-left">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="false" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="false" aria-disabled="false" aria-label="On" class="gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
@@ -183,7 +183,7 @@ exports[`gux-toggle #render should render component as expected (7) 1`] = `
     <div class="gux-toggle-container">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="true" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="true" aria-disabled="false" aria-label="on" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
@@ -221,7 +221,7 @@ exports[`gux-toggle #render should render component as expected (8) 1`] = `
     <div class="gux-toggle-container gux-toggle-label-left">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="false" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="false" aria-disabled="false" aria-label="This is a long label for the toggle to test how it works" class="gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
@@ -259,7 +259,7 @@ exports[`gux-toggle #render should render component as expected (9) 1`] = `
     <div class="gux-toggle-container">
       <div class="gux-toggle-input">
         <gux-toggle-slider>
-          <div aria-checked="true" aria-disabled="false" aria-labelledby="gux-toggle-label-i" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+          <div aria-checked="true" aria-disabled="false" aria-label="This is a long label for the toggle to test how it works" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
             <div class="gux-slider">
               <div class="gux-switch">
                 <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>


### PR DESCRIPTION
The screen reader now will only read the "checked" label.

The longer term fix would be for UX to implement a change to the design so that the toggle label does not change when the toggle is pressed 

additional context here https://inindca.atlassian.net/browse/COMUI-3181