### PR TITLE
fix(toggle): a11y deprecate checked and unchecked labels

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/example.html
@@ -1,79 +1,56 @@
+<h1>gux-toggle</h1>
+
+<p>
+  For accessibility reasons, we will be deprecating the
+  <strong>checkedLabel</strong> and <strong>uncheckedLabel</strong> props in v5.
+  Instead, use only the <strong>label</strong> prop as demonstrated below.
+</p>
+
 <div class="container">
-  <h1>gux-toggle</h1>
-  <gux-toggle checked-label="On" unchecked-label="Off"></gux-toggle>
+  <gux-toggle label="Dark Mode"></gux-toggle>
 
-  <gux-toggle checked-label="On" unchecked-label="Off" checked></gux-toggle>
+  <gux-toggle label="Dark Mode" checked></gux-toggle>
 
-  <gux-toggle
-    checked-label="Active"
-    unchecked-label="Inactive"
-    label-position="left"
-  ></gux-toggle>
+  <gux-toggle label="Dark Mode" label-position="left"></gux-toggle>
 
-  <gux-toggle checked-label="On" unchecked-label="Off" disabled></gux-toggle>
+  <gux-toggle label="Dark Mode" disabled></gux-toggle>
 
-  <gux-toggle
-    class="loading"
-    checked-label="Active"
-    unchecked-label="Inactive"
-    loading
-  ></gux-toggle>
+  <h3>Loading</h3>
+
+  <gux-toggle class="loading" label="Dark Mode" loading></gux-toggle>
+
+  <gux-toggle class="loading" label="Dark Mode" checked loading></gux-toggle>
+
+  <h3>Error Message</h3>
 
   <gux-toggle
-    class="loading"
-    checked-label="Active"
-    unchecked-label="Inactive"
-    checked
-    loading
-  ></gux-toggle>
-
-  <gux-toggle
-    checked-label="This is another long label for the toggle to show how it works"
-    unchecked-label="This is short"
-  ></gux-toggle>
-
-  <gux-toggle
-    checked-label="On"
-    unchecked-label="Off"
+    label="Dark Mode"
     error-message="This is an error message"
   ></gux-toggle>
 
   <gux-toggle
-    checked-label="On"
-    unchecked-label="Off"
+    label="Dark Mode"
     label-position="left"
     error-message="This is another error message"
   ></gux-toggle>
 
   <!-- inline gux-toggle -->
-  <div>
-    <gux-toggle
-      display-inline
-      checked-label="On"
-      unchecked-label="Off is long"
-    ></gux-toggle>
-    <gux-toggle
-      display-inline
-      checked-label="On"
-      unchecked-label="Off is long"
-      checked
-    ></gux-toggle>
-  </div>
-  <div>
-    <gux-toggle
-      display-inline
-      label-position="left"
-      checked-label="On"
-      unchecked-label="Off is long"
-    ></gux-toggle>
-    <gux-toggle
-      display-inline
-      label-position="left"
-      checked-label="On"
-      unchecked-label="Off is long"
-      checked
-    ></gux-toggle>
-  </div>
+  <h3>Inline</h3>
+  <gux-toggle display-inline label="Dark Mode"></gux-toggle>
+  <gux-toggle display-inline label="Dark Mode" checked></gux-toggle>
+</div>
+<div>
+  <gux-toggle
+    display-inline
+    label-position="left"
+    label="Dark Mode"
+  ></gux-toggle>
+  <gux-toggle
+    display-inline
+    label-position="left"
+    label="Dark Mode"
+    checked
+  ></gux-toggle>
 </div>
 
 <style

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle.tsx
@@ -42,8 +42,13 @@ export class GuxToggle {
   loading: boolean = false;
 
   @Prop()
+  label: string;
+
+  // Deprecated, remove in v5 COMUI-3368
+  @Prop()
   checkedLabel: string;
 
+  //Deprecated, remove in v5 COMUI-3368
   @Prop()
   uncheckedLabel: string;
 
@@ -90,6 +95,7 @@ export class GuxToggle {
   private getAriaLabel(): string {
     return (
       this.root.getAttribute('aria-label') ||
+      this.label ||
       this.checkedLabel ||
       this.root.title ||
       this.i18n('defaultAriaLabel')
@@ -116,7 +122,20 @@ export class GuxToggle {
   }
 
   private renderLabel(): JSX.Element {
-    if (this.uncheckedLabel && this.checkedLabel) {
+    if (this.label) {
+      return (
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id={this.labelId}>{this.label}</span>
+                {this.renderLoading()}
+              </span>
+            </div>
+          </div>
+        </div>
+      ) as JSX.Element;
+    } else if (this.uncheckedLabel && this.checkedLabel) {
       const labelText = this.checked ? this.checkedLabel : this.uncheckedLabel;
 
       return (

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.e2e.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.e2e.ts.snap
@@ -15,3 +15,19 @@ exports[`gux-toggle #render should render component as expected (6) 1`] = `""`;
 exports[`gux-toggle #render should render component as expected (7) 1`] = `""`;
 
 exports[`gux-toggle #render should render component as expected (8) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (9) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (10) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (11) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (12) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (13) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (14) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (15) 1`] = `""`;
+
+exports[`gux-toggle #render should render component as expected (16) 1`] = `""`;

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/__snapshots__/gux-toggle.spec.ts.snap
@@ -64,6 +64,261 @@ exports[`gux-toggle #render should render component as expected (3) 1`] = `
 `;
 
 exports[`gux-toggle #render should render component as expected (4) 1`] = `
+<gux-toggle label="On">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="false" aria-disabled="false" aria-label="On" class="gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  On
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (5) 1`] = `
+<gux-toggle checked="" label="on">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="true" aria-disabled="false" aria-label="on" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  on
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (6) 1`] = `
+<gux-toggle label="On" label-position="left">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container gux-toggle-label-left">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="false" aria-disabled="false" aria-label="On" class="gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  On
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (7) 1`] = `
+<gux-toggle checked="" label="on" label-position="right">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="true" aria-disabled="false" aria-label="on" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  on
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (8) 1`] = `
+<gux-toggle label="This is a long label for the toggle to test how it works" label-position="left">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container gux-toggle-label-left">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="false" aria-disabled="false" aria-label="This is a long label for the toggle to test how it works" class="gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  This is a long label for the toggle to test how it works
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (9) 1`] = `
+<gux-toggle checked="" label="This is a long label for the toggle to test how it works" label-position="right">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="true" aria-disabled="false" aria-label="This is a long label for the toggle to test how it works" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+        <div class="gux-toggle-label-and-error">
+          <div class="gux-toggle-label">
+            <div class="gux-toggle-label-text">
+              <span class="gux-toggle-label-text-inner">
+                <span id="gux-toggle-label-i">
+                  This is a long label for the toggle to test how it works
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (10) 1`] = `
+<gux-toggle>
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="false" aria-disabled="false" aria-label="Toggle Switch" class="gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (11) 1`] = `
+<gux-toggle checked="">
+  <template shadowrootmode="open">
+    <div class="gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="true" aria-disabled="false" aria-label="Toggle Switch" class="gux-checked gux-toggle-slider" role="checkbox" tabindex="0">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (12) 1`] = `
+<gux-toggle checked="" disabled="">
+  <template shadowrootmode="open">
+    <div class="gux-disabled gux-toggle-container">
+      <div class="gux-toggle-input">
+        <gux-toggle-slider>
+          <div aria-checked="true" aria-disabled="true" aria-label="Toggle Switch" class="gux-checked gux-disabled gux-toggle-slider" role="checkbox" tabindex="">
+            <div class="gux-slider">
+              <div class="gux-switch">
+                <gux-icon decorative="" icon-name="fa/check-solid"></gux-icon>
+              </div>
+            </div>
+          </div>
+        </gux-toggle-slider>
+      </div>
+    </div>
+    <gux-announce-beta></gux-announce-beta>
+  </template>
+</gux-toggle>
+`;
+
+exports[`gux-toggle #render should render component as expected (13) 1`] = `
 <gux-toggle checked-label="On" unchecked-label="Off">
   <template shadowrootmode="open">
     <div class="gux-toggle-container">
@@ -101,7 +356,7 @@ exports[`gux-toggle #render should render component as expected (4) 1`] = `
 </gux-toggle>
 `;
 
-exports[`gux-toggle #render should render component as expected (5) 1`] = `
+exports[`gux-toggle #render should render component as expected (14) 1`] = `
 <gux-toggle checked="" checked-label="on" unchecked-label="off">
   <template shadowrootmode="open">
     <div class="gux-toggle-container">
@@ -139,7 +394,7 @@ exports[`gux-toggle #render should render component as expected (5) 1`] = `
 </gux-toggle>
 `;
 
-exports[`gux-toggle #render should render component as expected (6) 1`] = `
+exports[`gux-toggle #render should render component as expected (15) 1`] = `
 <gux-toggle checked-label="On" label-position="left" unchecked-label="Off">
   <template shadowrootmode="open">
     <div class="gux-toggle-container gux-toggle-label-left">
@@ -177,7 +432,7 @@ exports[`gux-toggle #render should render component as expected (6) 1`] = `
 </gux-toggle>
 `;
 
-exports[`gux-toggle #render should render component as expected (7) 1`] = `
+exports[`gux-toggle #render should render component as expected (16) 1`] = `
 <gux-toggle checked="" checked-label="on" label-position="right" unchecked-label="off">
   <template shadowrootmode="open">
     <div class="gux-toggle-container">
@@ -215,7 +470,7 @@ exports[`gux-toggle #render should render component as expected (7) 1`] = `
 </gux-toggle>
 `;
 
-exports[`gux-toggle #render should render component as expected (8) 1`] = `
+exports[`gux-toggle #render should render component as expected (17) 1`] = `
 <gux-toggle checked-label="This is a long label for the toggle to test how it works" label-position="left" unchecked-label="This is another long label for the toggle to test how it works">
   <template shadowrootmode="open">
     <div class="gux-toggle-container gux-toggle-label-left">
@@ -253,7 +508,7 @@ exports[`gux-toggle #render should render component as expected (8) 1`] = `
 </gux-toggle>
 `;
 
-exports[`gux-toggle #render should render component as expected (9) 1`] = `
+exports[`gux-toggle #render should render component as expected (18) 1`] = `
 <gux-toggle checked="" checked-label="This is a long label for the toggle to test how it works" label-position="right" unchecked-label="This is another long label for the toggle to test how it works">
   <template shadowrootmode="open">
     <div class="gux-toggle-container">

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/gux-toggle.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/gux-toggle.e2e.ts
@@ -43,6 +43,29 @@ describe('gux-toggle', () => {
 
   describe('#render', () => {
     [
+      '<gux-toggle lang="en" label="On"></gux-toggle>',
+      '<gux-toggle lang="en" checked label="on"></gux-toggle>',
+      '<gux-toggle lang="en" id="disabledToggle" label="On" disabled></gux-toggle>',
+      '<gux-toggle lang="en" id="disabledToggle" checked label="on" disabled></gux-toggle>',
+      `<gux-toggle lang="en"
+        label="On"
+        label-position="left"
+      ></gux-toggle>`,
+      `<gux-toggle lang="en"
+        checked
+        label="on"
+        label-position="right"
+      ></gux-toggle>`,
+      `<gux-toggle lang="en"
+        label="This is a long label for the toggle to test how it works"
+        label-position="left"
+      ></gux-toggle>`,
+      `<gux-toggle lang="en"
+        checked
+        label="This is a long label for the toggle to test how it works"
+        label-position="right"
+      ></gux-toggle>`,
+      // remove deprecated props COMUI-3368
       '<gux-toggle lang="en" checked-label="On" unchecked-label="Off"></gux-toggle>',
       '<gux-toggle lang="en" checked checked-label="on" unchecked-label="off"></gux-toggle>',
       '<gux-toggle lang="en" id="disabledToggle" checked-label="On" unchecked-label="Off" disabled></gux-toggle>',
@@ -81,6 +104,121 @@ describe('gux-toggle', () => {
   });
 
   describe('User Interactions', () => {
+    [
+      {
+        name: 'clicked',
+        userInteraction: async (element: E2EElement) => await element.click()
+      }
+    ].forEach(({ name, userInteraction }) => {
+      describe(name, () => {
+        it(`should not fire a check event when an enabled toggle is disabled and ${name}`, async () => {
+          const html = '<gux-toggle lang="en" disabled label="On"</gux-toggle>';
+          const page = await newNonrandomE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const checkSpy = await element.spyOnEvent('check');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(checkSpy).toHaveLength(0);
+        });
+
+        it(`should fire a check event when an enabled toggle is ${name}`, async () => {
+          const html = '<gux-toggle lang="en" label="On"></gux-toggle>';
+          const page = await newNonrandomE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const checkSpy = await element.spyOnEvent('check');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(checkSpy).toHaveLength(1);
+        });
+
+        it(`should check an unchecked toggle when ${name}`, async () => {
+          const html = '<gux-toggle lang="en" label="On"></gux-toggle>';
+          const page = await newSparkE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          expect(await element.getProperty('checked')).toBe(false);
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(true);
+        });
+
+        it(`should uncheck a checked toggle when ${name}`, async () => {
+          const html = '<gux-toggle lang="en" checked label="On"></gux-toggle>';
+          const page = await newNonrandomE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          expect(await element.getProperty('checked')).toBe(true);
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(false);
+        });
+
+        it(`should not check an unchecked toggle when disabled and ${name}`, async () => {
+          const html =
+            '<gux-toggle lang="en" disabled label="On"></gux-toggle>';
+          const page = await newNonrandomE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          expect(await element.getProperty('checked')).toBe(false);
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(false);
+        });
+
+        it(`should not uncheck a checked toggle when disabled and ${name}`, async () => {
+          const html =
+            '<gux-toggle lang="en" checked disabled label="On"></gux-toggle>';
+          const page = await newNonrandomE2EPage({ html });
+          const element = await page.find('gux-toggle');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          expect(await element.getProperty('checked')).toBe(true);
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(true);
+        });
+
+        it(`should not check the toggle if preventDefault is called on the event`, async () => {
+          const html = '<gux-toggle lang="en" label="On"></gux-toggle>';
+          const page: E2EPage = await newNonrandomE2EPage({ html });
+          const element: E2EElement = await page.find('gux-toggle');
+          const toggleSlider = await element.find('pierce/gux-toggle-slider');
+
+          await page.evaluate(() => {
+            document.addEventListener('check', event => {
+              event.preventDefault();
+            });
+          });
+
+          expect(await element.getProperty('checked')).toBe(false);
+
+          await userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('User Interactions (deprecated checked-label and unchecked-label)', () => {
     [
       {
         name: 'clicked',

--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/gux-toggle.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/tests/gux-toggle.spec.ts
@@ -21,6 +21,30 @@ describe('gux-toggle', () => {
       '<gux-toggle></gux-toggle>',
       '<gux-toggle checked></gux-toggle>',
       '<gux-toggle checked disabled></gux-toggle>',
+      '<gux-toggle label="On"></gux-toggle>',
+      '<gux-toggle checked label="on"></gux-toggle>',
+      `<gux-toggle
+        label="On"
+        label-position="left"
+      ></gux-toggle>`,
+      `<gux-toggle
+        checked
+        label="on"
+        label-position="right"
+      ></gux-toggle>`,
+      `<gux-toggle
+        label="This is a long label for the toggle to test how it works"
+        label-position="left"
+      ></gux-toggle>`,
+      `<gux-toggle
+        checked
+        label="This is a long label for the toggle to test how it works"
+        label-position="right"
+      ></gux-toggle>`,
+      // remove deprecated props COMUI-3368
+      '<gux-toggle></gux-toggle>',
+      '<gux-toggle checked></gux-toggle>',
+      '<gux-toggle checked disabled></gux-toggle>',
       '<gux-toggle checked-label="On" unchecked-label="Off"></gux-toggle>',
       '<gux-toggle checked checked-label="on" unchecked-label="off"></gux-toggle>',
       `<gux-toggle
@@ -55,6 +79,111 @@ describe('gux-toggle', () => {
   });
 
   describe('User Interactions', () => {
+    [
+      {
+        name: 'clicked',
+        userInteraction: (element: HTMLElement) => element.click()
+      },
+      {
+        name: 'Space is pressed',
+        userInteraction: (element: HTMLElement) =>
+          element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }))
+      }
+    ].forEach(({ name, userInteraction }) => {
+      describe(name, () => {
+        it(`should not fire a check event when an enabled toggle is disabled and ${name}`, async () => {
+          const html = '<gux-toggle disabled label="On""></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          const checkSpy = jest.fn();
+
+          element.addEventListener('check', checkSpy);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(checkSpy).not.toHaveBeenCalled();
+        });
+
+        it(`should fire a check event when an enabled toggle is ${name}`, async () => {
+          const html = '<gux-toggle label="On"></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          const checkSpy = jest.fn();
+
+          element.addEventListener('check', checkSpy);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(checkSpy).toHaveBeenCalled();
+        });
+
+        it(`should check an unchecked toggle when ${name}`, async () => {
+          const html = '<gux-toggle label="On"></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          expect(element.checked).toBe(false);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(element.checked).toBe(true);
+        });
+
+        it(`should uncheck a checked toggle when ${name}`, async () => {
+          const html = '<gux-toggle checked label="On"></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          expect(element.checked).toBe(true);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(element.checked).toBe(false);
+        });
+
+        it(`should not check an unchecked toggle when disabled and ${name}`, async () => {
+          const html = '<gux-toggle disabled label="On"></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          expect(element.checked).toBe(false);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(element.checked).toBe(false);
+        });
+
+        it(`should not uncheck a checked toggle when disabled and ${name}`, async () => {
+          const html = '<gux-toggle checked disabled label="On"></gux-toggle>';
+          const page = await newSpecPage({ components, html, language });
+          const element = page.root as HTMLGuxToggleElement;
+          const toggleSlider =
+            element.shadowRoot.querySelector('gux-toggle-slider');
+          expect(element.checked).toBe(true);
+
+          userInteraction(toggleSlider);
+          await page.waitForChanges();
+
+          expect(element.checked).toBe(true);
+        });
+      });
+    });
+  });
+
+  // remove deprecated props COMUI-3368
+  describe('User Interactions (deprecated checked and unchecked label)', () => {
     [
       {
         name: 'clicked',


### PR DESCRIPTION
It is an accessibility violation to have a toggle change labels when checked.

This PR adds a `label` prop that should be used instead of the `checkedLabel` and `uncheckedLabel` props (which will be deprecated in v5)