### PR TITLE
feat(form-field-checkbox): adding aria attributes to help with error accessibility

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox-group/a11yManualChecklist.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox-group/a11yManualChecklist.md
@@ -1,0 +1,19 @@
+# gux-form-field-checkbox-group manual accessibility testing status
+
+**Last Updated:** 2025-01-16T11:30:31.187Z
+| Pass | WCAG Success Criterion | Notes |
+| --- | --- | --- |
+| ✅ | [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html) | - |
+| ✅ | [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html) | - |
+| ✅ | [2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html) | - |
+| ✅ | [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) | - |
+| ✅ | [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) | - |
+| ✅ | [2.4.11 Focus Not Obscured](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum) | - |
+| ✅ | [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html#dfn-name) | - |
+| ✅ | [2.5.7 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements) | - |
+| ✅ | [3.2.1 On Focus](https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html) | - |
+| ✅ | [3.2.2 On Input](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html) | - |
+| ✅ | [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html) | - |
+| ✅ | [3.2.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) | - |
+| ✅ | [4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html) | - |
+| ✅ | [4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html) | - |

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/a11yManualChecklist.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/a11yManualChecklist.md
@@ -1,0 +1,19 @@
+# gux-form-field-checkbox manual accessibility testing status
+
+**Last Updated:** 2025-01-16T10:31:51.869Z
+| Pass | WCAG Success Criterion | Notes |
+| --- | --- | --- |
+| ✅ | [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html) | - |
+| ✅ | [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html) | - |
+| ✅ | [2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html) | - |
+| ✅ | [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) | - |
+| ✅ | [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) | - |
+| ✅ | [2.4.11 Focus Not Obscured](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum) | - |
+| ✅ | [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html#dfn-name) | - |
+| ✅ | [2.5.7 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements) | - |
+| ✅ | [3.2.1 On Focus](https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html) | - |
+| ✅ | [3.2.2 On Input](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html) | - |
+| ✅ | [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html) | - |
+| ✅ | [3.2.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) | - |
+| ✅ | [4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html) | - |
+| ✅ | [4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html) | - |

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -95,7 +95,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -166,7 +166,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -95,7 +95,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -166,7 +166,7 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
@@ -61,9 +61,38 @@ describe('gux-form-field-checkbox', () => {
     `
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
+        const page = await newSpecPage({
+          components,
+          html,
+          language
+        });
+
+        // wait for change inside component
+        await page.waitForChanges();
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
+    describe('when the component has an error slot', () => {
+      it('should apply aria invalid and errormessage', async () => {
+        const html = `
+          <gux-form-field-checkbox>
+            <input slot="input" type="checkbox" name="food-1[]" value="pizza"/>
+            <label slot="label">Pizza</label>
+            <span slot="error">This is an error message</span>
+          </gux-form-field-checkbox>
+        `;
         const page = await newSpecPage({ components, html, language });
 
-        expect(page.root).toMatchSnapshot();
+        await page.waitForChanges();
+
+        expect(
+          page.root.querySelector('input').getAttribute('aria-invalid')
+        ).toBe('true');
+
+        expect(
+          page.root.querySelector('input').getAttribute('aria-errormessage')
+        ).toBeDefined();
       });
     });
   });

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
@@ -67,8 +67,6 @@ describe('gux-form-field-checkbox', () => {
           language
         });
 
-        // wait for change inside component
-        await page.waitForChanges();
         expect(page.root).toMatchSnapshot();
       });
     });
@@ -83,8 +81,6 @@ describe('gux-form-field-checkbox', () => {
           </gux-form-field-checkbox>
         `;
         const page = await newSpecPage({ components, html, language });
-
-        await page.waitForChanges();
 
         expect(
           page.root.querySelector('input').getAttribute('aria-invalid')

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-color #render error should render component as expected 1`] = `
+<gux-form-field-color>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="e-1" slot="input" type="color" value="#cc3ebe">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-color>
+`;
+
 exports[`gux-form-field-color #render help should render component as expected 1`] = `
 <gux-form-field-color>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.spec.ts
@@ -90,6 +90,21 @@ describe('gux-form-field-color', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-color>
+        <input slot="input" type="color" name="e-1" value="#cc3ebe" />
+        <label slot="label">Default</label>
+        <span slot="error">This is an error message</span>
+      </gux-form-field-color>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     it('should render the label info when provided', async () => {
       const html = `
             <gux-form-field-color>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/__snapshots__/gux-form-field-file.spec.ts.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-file #render error should render component as expected 1`] = `
+<gux-form-field-file>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <slot name="input"></slot>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <label for="avatar" slot="label">
+    Upload a profile picture
+  </label>
+  <input accept="image/png, image/jpeg" aria-describedby="gux-form-field-error-i" aria-invalid="true" id="avatar" name="avatar" slot="input" type="file">
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-file>
+`;
+
 exports[`gux-form-field-file #render help should render component as expected 1`] = `
 <gux-form-field-file>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/gux-form-field-file.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-file/tests/gux-form-field-file.spec.ts
@@ -120,6 +120,27 @@ describe('gux-form-field-file', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-file>
+        <label slot="label">Upload a profile picture</label>
+        <input
+          slot="input"
+          type="file"
+          id="avatar"
+          name="avatar"
+          accept="image/png, image/jpeg"
+        />
+        <span slot="error">This is an error message </span>
+      </gux-form-field-file>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
@@ -222,6 +222,53 @@ exports[`gux-form-field-number #render clearable should render component as expe
 </gux-form-field-number>
 `;
 
+exports[`gux-form-field-number #render error should render component as expected 1`] = `
+<gux-form-field-number>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error" part="input-section">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+          </div>
+          <div class="gux-step-buttons-container">
+            <button class="gux-step-button" tabindex="-1" title="Increment" type="button">
+              <gux-icon decorative="" icon-name="custom/chevron-up-small-regular"></gux-icon>
+            </button>
+            <button class="gux-step-button" tabindex="-1" title="Decrement" type="button">
+              <gux-icon decorative="" icon-name="custom/chevron-down-small-regular"></gux-icon>
+            </button>
+          </div>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="e-1" slot="input" type="number" value="10">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-number>
+`;
+
 exports[`gux-form-field-number #render help should render component as expected 1`] = `
 <gux-form-field-number>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.spec.ts
@@ -112,6 +112,21 @@ describe('gux-form-field-number', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-number>
+        <input slot="input" type="number" name="e-1" value="10" />
+        <label slot="label">Default</label>
+        <span slot="error">This is an error message</span>
+      </gux-form-field-number>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
@@ -95,7 +95,7 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -166,7 +166,7 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -203,7 +203,7 @@ exports[`gux-form-field-radio #render should render component as expected (6) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" disabled="" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" disabled="" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
@@ -95,7 +95,7 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -166,7 +166,7 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>
@@ -203,7 +203,7 @@ exports[`gux-form-field-radio #render should render component as expected (6) 1`
       </div>
     </div>
   </template>
-  <input aria-describedby="gux-form-field-error-i" aria-errormessage="gux-form-field-error-i" aria-invalid="true" disabled="" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" disabled="" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="pizza">
   <label for="gux-form-field-input-i" slot="label">
     Pizza
   </label>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-search #render error should render component as expected 1`] = `
+<gux-form-field-search>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error">
+          <div class="gux-input-container">
+            <gux-icon decorative="" icon-name="fa/magnifying-glass-regular"></gux-icon>
+            <slot name="input"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="e-1" slot="input" type="search">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-search>
+`;
+
 exports[`gux-form-field-search #render help should render component as expected 1`] = `
 <gux-form-field-search>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.spec.ts
@@ -90,6 +90,21 @@ describe('gux-form-field-search', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-search>
+        <input slot="input" type="search" name="e-1" />
+        <label slot="label">Default</label>
+        <span slot="error">This is an error message</span>
+      </gux-form-field-search>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-select #render error should render component as expected 1`] = `
+<gux-form-field-select>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+            <gux-icon decorative="" icon-name="custom/chevron-down-small-regular"></gux-icon>
+          </div>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <select aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="e-1" slot="input">
+    <option value="option1">
+      Option 1
+    </option>
+    <option value="option2">
+      Option 2
+    </option>
+    <option value="option3">
+      Option 3
+    </option>
+  </select>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-select>
+`;
+
 exports[`gux-form-field-select #render help should render component as expected 1`] = `
 <gux-form-field-select>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.spec.ts
@@ -109,6 +109,25 @@ describe('gux-form-field-select', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-select>
+        <select slot="input" name="e-1">
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </select>
+        <label slot="label">Default</label>
+        <span slot="error">This is an error message</span>
+      </gux-form-field-select>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
@@ -192,6 +192,47 @@ exports[`gux-form-field-text-like #render clearable should render component as e
 </gux-form-field-text-like>
 `;
 
+exports[`gux-form-field-text-like #render error should render component as expected 1`] = `
+<gux-form-field-text-like>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error">
+          <div class="gux-input-container">
+            <slot name="prefix"></slot>
+            <slot name="input"></slot>
+            <slot name="suffix"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  <input aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="e-1" slot="input" type="text">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-text-like>
+`;
+
 exports[`gux-form-field-text-like #render help should render component as expected 1`] = `
 <gux-form-field-text-like>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.spec.ts
@@ -109,6 +109,21 @@ describe('gux-form-field-text-like', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+          <gux-form-field-text-like>
+          <input slot="input" type="text" name="e-1" />
+          <label slot="label">Default</label>
+          <span slot="error">This is an error message</span>
+        </gux-form-field-text-like>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-textarea #render error should render component as expected 1`] = `
+<gux-form-field-textarea>
+  <template shadowrootmode="open">
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+        <gux-form-field-label-indicator variant="required"></gux-form-field-label-indicator>
+        <slot name="label-info"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-input-error gux-resize-undefined">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-form-field-error gux-show">
+          <gux-icon decorative="" icon-name="fa/hexagon-exclamation-solid"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template><textarea aria-describedby="gux-form-field-error-i" aria-invalid="true" id="gux-form-field-input-i" name="textarea" slot="input"></textarea>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-error-i" slot="error">
+    This is an error message
+  </span>
+</gux-form-field-textarea>
+`;
+
 exports[`gux-form-field-textarea #render help should render component as expected 1`] = `
 <gux-form-field-textarea>
   <template shadowrootmode="open">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.spec.ts
@@ -108,6 +108,21 @@ describe('gux-form-field-textarea', () => {
       });
     });
 
+    describe('error', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-textarea>
+        <textarea slot="input" name="textarea"></textarea>
+        <label slot="label">Default</label>
+        <span slot="error">This is an error message</span>
+      </gux-form-field-textarea>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-info', () => {
       it('should render component as expected', async () => {
         const html = `

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/gux-form-field.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/gux-form-field.service.ts
@@ -83,9 +83,12 @@ export function validateFormIds(
     error.setAttribute('id', errorId);
     describedByIds.push(errorId);
 
-    if (input instanceof HTMLInputElement) {
+    if (
+      input.tagName === 'INPUT' ||
+      input.tagName === 'SELECT' ||
+      input.tagName === 'TEXTAREA'
+    ) {
       input.setAttribute('aria-invalid', 'true');
-      input.setAttribute('aria-errormessage', errorId);
     }
 
     if (describedByIds) {

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/gux-form-field.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/gux-form-field.service.ts
@@ -83,6 +83,11 @@ export function validateFormIds(
     error.setAttribute('id', errorId);
     describedByIds.push(errorId);
 
+    if (input instanceof HTMLInputElement) {
+      input.setAttribute('aria-invalid', 'true');
+      input.setAttribute('aria-errormessage', errorId);
+    }
+
     if (describedByIds) {
       input.setAttribute('aria-describedby', describedByIds.join(' '));
     }


### PR DESCRIPTION
Adds 2 aria attributes to the form-field-checkbox & form-field-radio.

See: https://www.smashingmagazine.com/2023/02/guide-accessible-form-validation/
[aria-invalid](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid)
[aria-errormessage](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage)

aria-errormessage has partial support - https://a11ysupport.io/tech/aria/aria-errormessage_attribute