### PR TITLE
fix(option): trim whitespace for subtext selection

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -438,13 +438,11 @@ export class GuxDropdown {
   }
 
   private renderOption(option: HTMLGuxOptionElement): JSX.Element {
-    let optionText = option.textContent;
+    let optionText = option.textContent.trim();
     if (hasSlot(option, 'subtext')) {
+      // TODO: use getOptionDefaultSlot(option)?.textContent.trim() once Stencil fix for assignedNodes test issue is in (v4.27.2)
       const subtext = option.querySelector('[slot=subtext]');
-      optionText = optionText.substring(
-        0,
-        optionText.length - subtext.textContent.length
-      );
+      optionText = optionText.replace(subtext.textContent, '');
     }
     return (
       <gux-truncate ref={el => (this.truncateElement = el)} dir="auto">


### PR DESCRIPTION
✅ Closes: COMUI-3491

Here's an example for testing:
```
<gux-option value="us-east-1" id="gux-option-4qupoj7mux" role="option" class="gux-show-subtext gux-selected" aria-selected="true" aria-disabled="false" hydrated=""><!--?lit$820817559$-->Americas (US East) (<!--?lit$820817559$-->us-east-1)

        <span slot="subtext">
https://login.mypurecloud.com</span>
      </gux-option>
```