### PR TITLE
feat(other) - upgrade stencil to latest to fix memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5152,9 +5152,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
-      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.26.0.tgz",
+      "integrity": "sha512-+0Inu+dJ9/LgWSskcZwx7v17v4GILcwIYxNgD+OuK0U+D5z61WsxWw7yHkYG5OqGPBijsJMVssYRx/Tn+e7F9A==",
       "dev": true,
       "bin": {
         "stencil": "bin/stencil"
@@ -24509,7 +24509,7 @@
       "devDependencies": {
         "@babel/core": "^7.26.8",
         "@babel/preset-env": "^7.26.8",
-        "@stencil/core": "4.20.0",
+        "@stencil/core": "4.26.0",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/sass": "^3.0.12",
         "@types/jest": "^29.5.14",
@@ -24713,7 +24713,7 @@
       "devDependencies": {
         "@babel/core": "^7.26.8",
         "@babel/preset-env": "^7.26.8",
-        "@stencil/core": "4.20.0",
+        "@stencil/core": "4.26.0",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/sass": "^3.0.12",
         "@types/google-libphonenumber": "^7.4.30",

--- a/packages/genesys-spark-chart-components/package.json
+++ b/packages/genesys-spark-chart-components/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.8",
     "@babel/preset-env": "^7.26.8",
-    "@stencil/core": "4.20.0",
+    "@stencil/core": "4.26.0",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/sass": "^3.0.12",
     "@types/jest": "^29.5.14",

--- a/packages/genesys-spark-chart-components/stencil.config.ts
+++ b/packages/genesys-spark-chart-components/stencil.config.ts
@@ -62,7 +62,7 @@ export const config: Config = {
     moduleNameMapper: {
       '@utils/(.*)': '<rootDir>/src/utils/$1'
     },
-    browserHeadless: true,
+    browserHeadless: 'shell',
     collectCoverage: true,
     coverageDirectory: 'build/test-reports/coverage',
     coverageReporters: ['json', 'lcov', 'clover'],

--- a/packages/genesys-spark-components/package.json
+++ b/packages/genesys-spark-components/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.8",
     "@babel/preset-env": "^7.26.8",
-    "@stencil/core": "4.20.0",
+    "@stencil/core": "4.26.0",
     "@stencil/react-output-target": "^0.5.3",
     "@stencil/sass": "^3.0.12",
     "@types/google-libphonenumber": "^7.4.30",

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -756,7 +756,7 @@ export class GuxDatepicker {
   renderCalendar(): JSX.Element {
     return (
       <gux-calendar
-        tabIndex={-1}
+        tabindex="-1"
         ref={(el: HTMLGuxCalendarElement) => (this.calendarElement = el)}
         value={this.value}
         mode={this.mode}

--- a/packages/genesys-spark-components/stencil.config.ts
+++ b/packages/genesys-spark-components/stencil.config.ts
@@ -68,7 +68,7 @@ export const config: Config = {
     moduleNameMapper: {
       '@utils/(.*)': '<rootDir>/src/utils/$1'
     },
-    browserHeadless: true,
+    browserHeadless: 'shell',
     collectCoverage: true,
     coverageDirectory: 'build/test-reports/coverage',
     coverageReporters: ['json', 'lcov', 'clover'],


### PR DESCRIPTION
**Note**
So this update was not as straightforward as I thought. When I run the tests locally nearly all the snapshots fail for some reason and tons of other tests fail for different reasons like timeouts. I tried to do some debugging around it. My first thought was that maybe puppeteer needs to be updated but this did not resolve it.

I also just tried pinning it to the version that the `memory leak` was fixed in which was version `4.23.2` but still the same issue with tests arises.

I then tried just updating to a version after our current version. The current version we are on is `4.20.0` so I updated to `4.21.0` and the same result which I found weird.

Here is a list of releases where I cannot seem to find where this issue could be stemming from (https://github.com/ionic-team/stencil/releases?page=1)

**Additional Packages**
I dont think we have to update the `react-output-target` package as we are above the minimum required package so that should have no impact to react teams. See here (https://stenciljs.com/docs/v4.0/introduction/upgrading-to-stencil-four#additional-packages)