### PR TITLE
fix(tooltip): add animation delay for when showing tooltip

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-tooltip-base/gux-tooltip-base.scss
@@ -13,6 +13,7 @@
   display: block;
   animation-name: fade-in;
   animation-duration: 250ms;
+  animation-delay: 350ms;
   animation-fill-mode: forwards;
 }
 

--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.scss
@@ -13,6 +13,7 @@
   display: block;
   animation-name: fade-in;
   animation-duration: 250ms;
+  animation-delay: 350ms;
   animation-fill-mode: forwards;
 }
 


### PR DESCRIPTION
**Note**
I re-added the animation delay of `350ms` for when showing the tooltip as this was causing issues with tooltips overlapping as the tooltip would show if you just brush over the target element. See video below, . I think this works fine and is outlined here to wait `0.3-5` so that you know the users intent when hovering over the target area (https://www.nngroup.com/articles/timing-exposing-content/#:~:text=Wait-,0.3%E2%80%930.5%20seconds.,-If%20cursor%20remains) . This does not regress the accessibility changes made in (https://inindca.atlassian.net/browse/COMUI-3420) so the user can still hover over the tooltip content.

https://github.com/user-attachments/assets/e7da9c97-1267-4c84-ab32-90534c4ff537

