### PR TITLE
chore(packages/genesys-spark-components-react/package.json): update peer deps for React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24793,9 +24793,9 @@
         "typescript": "5.5.4"
       },
       "peerDependencies": {
-        "@types/react": "16 - 18",
-        "react": "16 - 18",
-        "react-dom": "16 - 18"
+        "@types/react": "16 - 19",
+        "react": "16 - 19",
+        "react-dom": "16 - 19"
       }
     },
     "packages/genesys-spark-components-react/node_modules/typescript": {

--- a/packages/genesys-spark-components-react/package.json
+++ b/packages/genesys-spark-components-react/package.json
@@ -22,9 +22,9 @@
     "genesys-spark-components": "^4.118.0"
   },
   "peerDependencies": {
-    "@types/react": "16 - 18",
-    "react": "16 - 18",
-    "react-dom": "16 - 18"
+    "@types/react": "16 - 19",
+    "react": "16 - 19",
+    "react-dom": "16 - 19"
   },
   "devDependencies": {
     "@types/react": "17.0.76",


### PR DESCRIPTION
Update the peer dependencies to allow projects to use React 19 without warnings