### PR TITLE
fix(side-panel-beta): remove flex display from content

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-side-panel/gux-side-panel.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-side-panel/gux-side-panel.scss
@@ -59,7 +59,6 @@
   }
 
   & .gux-side-panel-content {
-    display: flex;
     flex: 1 1 100%;
     padding: var(--gse-ui-sidePanel-body-padding);
     overflow-y: auto;


### PR DESCRIPTION
Removed the `display:flex` on the side-panel-content container as its not needed.

[✅ Closes: COMUI-3502](https://inindca.atlassian.net/browse/COMUI-3502)