### PR TITLE
fix(copy-to-clipboard): display none on tooltip when hidden

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/gux-copy-to-clipboard.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/gux-copy-to-clipboard.scss
@@ -59,7 +59,7 @@ button {
   }
 }
 
-gux-tooltip {
+gux-tooltip.gux-show {
   display: inline-flex;
   align-items: center;
 


### PR DESCRIPTION
COMUI-3518

There are behaviour questions that need to be worked out in relation to the tooltip also but this is something we should fix. 

Before:
tooltip can be reactivated by hovering over the area where it was previously shown
https://github.com/user-attachments/assets/c6856ccd-4a2d-4e00-8263-cd4a7673a7c1


After:
tooltip can be hovered over when displayed but when dismissed, it must be again triggered by the owning element 
https://github.com/user-attachments/assets/202b84f4-c79c-47a5-a9fc-9d52642152c1


