### PR TITLE
fix(other): update localization logic to treat `en-us` dom lang as `en`

### DIFF
--- a/packages/genesys-spark-chart-components/src/genesys-spark-utils/intl.ts
+++ b/packages/genesys-spark-chart-components/src/genesys-spark-utils/intl.ts
@@ -68,12 +68,13 @@ export function determineDisplayLocale(
 ): string {
   const domLocale = (getClosestElement(element, '*[lang]') as HTMLElement)
     ?.lang;
-  if (!domLocale || browserHasRegionData(domLocale)) {
+  const domLocaleWithOverride = domLocaleOverride(domLocale);
+  if (!domLocaleWithOverride || browserHasRegionData(domLocaleWithOverride)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.
     return navigator.language;
   } else {
-    return domLocale;
+    return domLocaleWithOverride;
   }
 }
 
@@ -89,6 +90,16 @@ function browserHasRegionData(localeString: string): boolean {
     (localeString.length == 2 &&
       navigator.language?.startsWith(`${localeString}-`))
   );
+}
+
+// Currently, login page and web-directory store the English user selection as `en-us`.
+// We will remove this override once those apps migrate from using en-us to en as part of a future epic.
+function domLocaleOverride(localeString: string): string {
+  if (localeString.toLowerCase() === 'en-us') {
+    return 'en';
+  } else {
+    return localeString;
+  }
 }
 
 function browserLocaleOverride(localeString: string): boolean {

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-list/gux-month-list-item/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-list/gux-month-list-item/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type                        | Default     |
-| ---------- | ---------- | ----------- | --------------------------- | ----------- |
-| `disabled` | `disabled` |             | `boolean`                   | `false`     |
-| `selected` | `selected` |             | `boolean`                   | `false`     |
-| `value`    | `value`    |             | `` `${string}-${string}` `` | `undefined` |
+| Property   | Attribute  | Description | Type                    | Default     |
+| ---------- | ---------- | ----------- | ----------------------- | ----------- |
+| `disabled` | `disabled` |             | `boolean`               | `false`     |
+| `selected` | `selected` |             | `boolean`               | `false`     |
+| `value`    | `value`    |             | ``${string}-${string}`` | `undefined` |
 
 
 ## Dependencies

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                     | Type                        | Default     |
-| -------- | --------- | --------------------------------------------------------------- | --------------------------- | ----------- |
-| `max`    | `max`     | The max year and month selectable in ISO8601 format (yyyy-mm)   | `` `${string}-${string}` `` | `undefined` |
-| `min`    | `min`     | The min year and month selectable in ISO8601 format (yyyy-mm)   | `` `${string}-${string}` `` | `undefined` |
-| `value`  | `value`   | The current selected year and month in ISO8601 format (yyyy-mm) | `` `${string}-${string}` `` | `undefined` |
+| Property | Attribute | Description                                                     | Type                    | Default     |
+| -------- | --------- | --------------------------------------------------------------- | ----------------------- | ----------- |
+| `max`    | `max`     | The max year and month selectable in ISO8601 format (yyyy-mm)   | ``${string}-${string}`` | `undefined` |
+| `min`    | `min`     | The min year and month selectable in ISO8601 format (yyyy-mm)   | ``${string}-${string}`` | `undefined` |
+| `value`  | `value`   | The current selected year and month in ISO8601 format (yyyy-mm) | ``${string}-${string}`` | `undefined` |
 
 
 ## Methods

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                     | Type                        | Default     |
-| ---------- | ---------- | --------------------------------------------------------------- | --------------------------- | ----------- |
-| `disabled` | `disabled` |                                                                 | `boolean`                   | `false`     |
-| `max`      | `max`      | The max year and month selectable in ISO8601 format (yyyy-mm)   | `` `${string}-${string}` `` | `undefined` |
-| `min`      | `min`      | The min year and month selectable in ISO8601 format (yyyy-mm)   | `` `${string}-${string}` `` | `undefined` |
-| `value`    | `value`    | The current selected year and month in ISO8601 format (yyyy-mm) | `` `${string}-${string}` `` | `undefined` |
+| Property   | Attribute  | Description                                                     | Type                    | Default     |
+| ---------- | ---------- | --------------------------------------------------------------- | ----------------------- | ----------- |
+| `disabled` | `disabled` |                                                                 | `boolean`               | `false`     |
+| `max`      | `max`      | The max year and month selectable in ISO8601 format (yyyy-mm)   | ``${string}-${string}`` | `undefined` |
+| `min`      | `min`      | The min year and month selectable in ISO8601 format (yyyy-mm)   | ``${string}-${string}`` | `undefined` |
+| `value`    | `value`    | The current selected year and month in ISO8601 format (yyyy-mm) | ``${string}-${string}`` | `undefined` |
 
 
 ## Dependencies

--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/readme.md
@@ -17,7 +17,7 @@
 | `min`       | `min`        |             | `string`                               | `undefined` |
 | `required`  | `required`   |             | `boolean`                              | `false`     |
 | `step`      | `step`       |             | `1 \| 10 \| 15 \| 20 \| 30 \| 5 \| 60` | `1`         |
-| `value`     | `value`      |             | `` `${string}:${string}` ``            | `'00:00'`   |
+| `value`     | `value`      |             | ``${string}:${string}``                | `'00:00'`   |
 
 
 ## Dependencies

--- a/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
+++ b/packages/genesys-spark-components/src/genesys-spark-utils/intl.ts
@@ -68,12 +68,13 @@ export function determineDisplayLocale(
 ): string {
   const domLocale = (getClosestElement(element, '*[lang]') as HTMLElement)
     ?.lang;
-  if (!domLocale || browserHasRegionData(domLocale)) {
+  const domLocaleWithOverride = domLocaleOverride(domLocale);
+  if (!domLocaleWithOverride || browserHasRegionData(domLocaleWithOverride)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.
     return navigator.language;
   } else {
-    return domLocale;
+    return domLocaleWithOverride;
   }
 }
 
@@ -89,6 +90,16 @@ function browserHasRegionData(localeString: string): boolean {
     (localeString.length == 2 &&
       navigator.language?.startsWith(`${localeString}-`))
   );
+}
+
+// Currently, login page and web-directory store the English user selection as `en-us`.
+// We will remove this override once those apps migrate from using en-us to en as part of a future epic.
+function domLocaleOverride(localeString: string): string {
+  if (localeString.toLowerCase() === 'en-us') {
+    return 'en';
+  } else {
+    return localeString;
+  }
 }
 
 function browserLocaleOverride(localeString: string): boolean {

--- a/packages/genesys-spark/snapshot/index.js
+++ b/packages/genesys-spark/snapshot/index.js
@@ -151,15 +151,23 @@ function relativeTimeFormat(localeOrOptions, options) {
 function determineDisplayLocale(element = document.body) {
   var _a;
   const domLocale = (_a = getClosestElement(element, "*[lang]")) == null ? void 0 : _a.lang;
-  if (!domLocale || browserHasRegionData(domLocale)) {
+  const domLocaleWithOverride = domLocaleOverride(domLocale);
+  if (!domLocaleWithOverride || browserHasRegionData(domLocaleWithOverride)) {
     return navigator.language;
   } else {
-    return domLocale;
+    return domLocaleWithOverride;
   }
 }
 function browserHasRegionData(localeString) {
   var _a;
   return browserLocaleOverride(localeString) || localeString.length == 2 && ((_a = navigator.language) == null ? void 0 : _a.startsWith(`${localeString}-`));
+}
+function domLocaleOverride(localeString) {
+  if ((localeString == null ? void 0 : localeString.toLowerCase()) === "en-us") {
+    return "en";
+  } else {
+    return localeString;
+  }
 }
 function browserLocaleOverride(localeString) {
   var _a, _b;

--- a/packages/genesys-spark/src/utils/intl.ts
+++ b/packages/genesys-spark/src/utils/intl.ts
@@ -68,12 +68,13 @@ export function determineDisplayLocale(
 ): string {
   const domLocale = (getClosestElement(element, '*[lang]') as HTMLElement)
     ?.lang;
-  if (!domLocale || browserHasRegionData(domLocale)) {
+  const domLocaleWithOverride = domLocaleOverride(domLocale);
+  if (!domLocaleWithOverride || browserHasRegionData(domLocaleWithOverride)) {
     // If we can't find a locale in the DOM, or we find a locale without a region that matches the
     // users's browser locale, use the browser locale.
     return navigator.language;
   } else {
-    return domLocale;
+    return domLocaleWithOverride;
   }
 }
 
@@ -89,6 +90,16 @@ function browserHasRegionData(localeString: string): boolean {
     (localeString.length == 2 &&
       navigator.language?.startsWith(`${localeString}-`))
   );
+}
+
+// Currently, login page and web-directory store the English user selection as `en-us`.
+// We will remove this override once those apps migrate from using en-us to en as part of a future epic.
+function domLocaleOverride(localeString: string): string {
+  if (localeString?.toLowerCase() === 'en-us') {
+    return 'en';
+  } else {
+    return localeString;
+  }
 }
 
 function browserLocaleOverride(localeString: string): boolean {

--- a/packages/genesys-spark/test/intl.spec.ts
+++ b/packages/genesys-spark/test/intl.spec.ts
@@ -49,6 +49,15 @@ describe('The intl module', () => {
       document.body.setAttribute('lang', 'yy');
       expect(determineDisplayLocale()).toBe('yy-YY');
     });
+    // Test dom region override
+    test('If the dom language is set to en-US, and the browser language is regional variant of English, use the browser region', () => {
+      Object.defineProperty(window.navigator, 'language', {
+        value: 'en-GB',
+        configurable: true
+      });
+      document.body.setAttribute('lang', 'en-US');
+      expect(determineDisplayLocale()).toBe('en-GB');
+    });
     // Test browser region overrides
     test('If the language attribute is zh-TW (Traditional Chinese Taiwan) and the browser language is Hong Kong then use the browser region', () => {
       Object.defineProperty(window.navigator, 'language', {


### PR DESCRIPTION
Web directory and the login page are setting the English language as `en-us`, which means the browser locale logic is not being taken into account. For now, if the dom language is set as `en-us` we will change this to `en` so that the browser region can be applied. There is a future epic planned for these applications to migrate away from setting `en-us` and at that time we will remove this override logic.