### PR TITLE
fix(popover-beta): add preventDefault when opening popover

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-popover-beta/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popover-beta/gux-popover.tsx
@@ -271,6 +271,7 @@ export class GuxPopover {
     switch (event.key) {
       case 'Enter':
       case ' ':
+        event.preventDefault();
         this.popupElement.togglePopover();
         this.isOpen = !this.isOpen;
         this.runUpdatePosition();


### PR DESCRIPTION
There was a bug where the autofocused button was being clicked when popover is opened using 'enter' key. This pr fixes this by adding `event.preventDefault()` when opening the popover using the keyboard