### PR TITLE
chore(time-picker): Changed minutes and hours inputs to number type (WIP)

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.scss
@@ -52,12 +52,17 @@
       padding: 0;
       font-size: var(--gse-ui-formControl-label-text-fontSize);
       color: var(--gse-ui-formControl-input-populatedColor);
-      outline: none;
       background-color: var(--gse-ui-formControl-input-backgroundColor);
       border: none;
+      outline: none;
 
       &.gux-input-time-hours {
         text-align: end;
+        -moz-appearance: textfield;
+      }
+
+      &.gux-input-time-minutes {
+        -moz-appearance: textfield;
       }
 
       &::placeholder {
@@ -76,9 +81,9 @@
       font-weight: var(--gse-ui-formControl-input-prefixSufix-text-fontWeight);
       line-height: var(--gse-ui-formControl-input-prefixSufix-text-lineHeight);
       color: var(--gse-ui-formControl-input-populatedColor);
-      outline: none;
       background: transparent;
       border: none;
+      outline: none;
 
       &:focus-visible {
         @include focus.gux-focus-ring-small;
@@ -107,9 +112,9 @@
       order: 0;
       padding: 0;
       color: var(--gse-ui-formControl-input-inputIcon-iconEndColor);
-      outline: none;
       background: transparent;
       border: none;
+      outline: none;
 
       &.gux-active:not(:disabled) {
         color: var(--gse-ui-timePicker-clockStates-activeColor);

--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.service.ts
@@ -175,9 +175,9 @@ export function getValue(
 export function getHourDisplayValue(
   value: GuxISOHourMinute,
   clockType: GuxClockType
-): string {
+): number {
   const [hour] = getDisplayValue(value, clockType).split(':');
-  return hour;
+  return parseInt(hour, 10);
 }
 
 export function getMinuteDisplayValue(value: GuxISOHourMinute): string {

--- a/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-time-picker/gux-time-picker.tsx
@@ -326,7 +326,7 @@ export class GuxTimePicker {
       <div class="gux-input-time-container">
         <input
           class="gux-input-time-hours"
-          type="text"
+          type="number"
           disabled={this.disabled}
           value={getHourDisplayValue(this.value, this.clockType)}
           onKeyDown={e => this.onHourKeyDown(e)}
@@ -337,7 +337,7 @@ export class GuxTimePicker {
         <span class="gux-time-separator">{this.i18n('time-separator')}</span>
         <input
           class="gux-input-time-minutes"
-          type="text"
+          type="number"
           disabled={this.disabled}
           value={getMinuteDisplayValue(this.value)}
           onKeyDown={e => this.onMinuteKeyDown(e)}


### PR DESCRIPTION
✅ Closes: COMUI-3410

(WIP)

This PR is not complete but in a state where I was wondering if I could get feedback. The ask in this ticket was to have voiceover announce that the hours and minutes input fields are steppers, so changing the input type from string to number will fix this, however, you'll notice that there's an issue on input change if you enter a number that's outside the appropriate range (e.g. 45 for hours or 143 for minutes as examples). I noticed there's a lot of logic in `getValidValueHourChange` and `getValidValueMinuteChange` that get called on hours or minutes input change. Is there a reason we needed the input type to be text instead of number? I feel like it's possible we could simplify a lot of this logic if the input type is number and then we don't need regex's, and could validate based on a number instead of string value. But wanted to check with the team first.