### PR TITLE
fix(tooltip): fix invalid html on examples page

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/example.html
@@ -21,11 +21,11 @@
     <strong>Hover</strong> over this paragraph to seen an example of a tooltip
     with more text.
     <gux-tooltip
-      ><div slot="content">
+      ><span slot="content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac odio a
         dolor semper vehicula at ut nulla. Proin pellentesque neque sollicitudin
         iaculis efficitur.
-      </div>
+      </span>
     </gux-tooltip>
   </p>
 </section>


### PR DESCRIPTION
`div` cannot be inside a `p` element

[✅ Closes: COMUI-3585](https://inindca.atlassian.net/browse/COMUI-3585)