### PR TITLE
fix(tooltip): hide tooltip when tab regains visbility

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -146,10 +146,6 @@ export class GuxTooltip {
     );
   }
 
-  private handleToolTip(): void {
-    this.show();
-  }
-
   private updatePosition(): void {
     const middleware = [
       offset(16),


### PR DESCRIPTION
So I am not 100% happy with this solution but just wanted to bring light to the issue at hand.

Steps to reproduce : 

1. Copy the following markup in the example docs,

`<gux-button accent="primary" onclick="notify(event)"><gux-tooltip><span slot="content">slot</span></gux-tooltip></gux-button>`

2. If you click on the button then switch to a new tab in chrome and then go back to the tab with the button the tooltip should reappear without touching the element but we obviously do not want this to occur.

This happens due to how browsers work and that when the tab regains visibility it will apply focus to the last element that was in focus which in this case is the `gux-button`.

This causes issues with the `tooltip` as we have a `focusin` event listener applied which executes the `this.show()` which is correct as we need this for keyboard users to display the tooltip.

But seeing as the focus is reapplied to the button this will in turn show the tooltip automatically which is undesirable.

My fix does resolve the issue but but only for tab-switches which was outlined in the ticket. It does not work if you click on a totally different browser window and then come back to this browser window the issue will occur again

I checked the native elements when tab switching and they do regain focus so I cannot make any changes to gux-button.

[✅ Closes: COMUI-3593](https://inindca.atlassian.net/browse/COMUI-3593)