### PR TITLE
fix(toast): Break word on message

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-toast/gux-toast.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-toast/gux-toast.scss
@@ -71,6 +71,7 @@
         font-family: var(--gse-ui-toast-text-fontFamily);
         font-size: var(--gse-ui-toast-text-fontSize);
         line-height: var(--gse-ui-toast-text-lineHeight);
+        word-break: break-all;
       }
     }
 


### PR DESCRIPTION
✅ Closes: COMUI-3635

To see the issue add this to docs:
```
<gux-toast toast-type="success">
  <div slot="title">Success Example</div>
  <div slot="message">accountswitcherdcatestuser2@account-switcherdca.test account successfully removed</div>
</gux-toast>
```