### PR TITLE
perf(form-field): announcing error states [Feedback]

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/example.html
@@ -5,219 +5,55 @@
 <h2>Examples</h2>
 <form onchange="notify(event)" oninput="notify(event)">
   <fieldset>
-    <legend>Clearable</legend>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="c-1" value="10" />
-      <label slot="label">Default</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number clearable>
-      <input slot="input" type="number" name="c-2" value="10" />
-      <label slot="label">True</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number clearable>
-      <input slot="input" type="number" name="c-3" value="10" disabled />
-      <label slot="label">True and disabled</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number clearable="false">
-      <input slot="input" type="number" name="c-4" value="10" />
-      <label slot="label">False</label>
-    </gux-form-field-number>
-  </fieldset>
-
-  <fieldset>
-    <legend>Label Position</legend>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="lp-1" value="10" />
-      <label slot="label">Default</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="lp-2" value="10" />
-      <label slot="label">Default long label</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number label-position="above">
-      <input slot="input" type="number" name="lp-3" value="10" />
-      <label slot="label">Above</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number label-position="beside">
-      <input slot="input" type="number" name="lp-4" value="10" />
-      <label slot="label">Beside</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number label-position="screenreader">
-      <input slot="input" type="number" name="lp-5" value="10" />
-      <label slot="label">Screenreader</label>
-    </gux-form-field-number>
-  </fieldset>
-
-  <fieldset>
-    <legend>Input attributes</legend>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="a-1" value="10" disabled />
-      <label slot="label">Disabled</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="a-2" value="10" required />
-      <label slot="label">Required</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number>
-      <input slot="input" type="number" name="a-3" placeholder="Enter number" />
-      <label slot="label">Placeholder</label>
-    </gux-form-field-number>
-
-    <gux-form-field-number>
-      <input
-        slot="input"
-        type="number"
-        name="a-2"
-        value="10"
-        step="5"
-        min="-25"
-        max="25"
-      />
-      <label slot="label">Step / Min / Max</label>
-    </gux-form-field-number>
-  </fieldset>
-
-  <fieldset>
     <legend>Error</legend>
 
-    <gux-form-field-number>
+    <gux-form-field-number id="numberField">
       <input slot="input" type="number" name="e-1" value="10" />
       <label slot="label">Default</label>
-      <span slot="error">This is an error message</span>
     </gux-form-field-number>
-  </fieldset>
-
-  <fieldset>
-    <legend>Help</legend>
 
     <gux-form-field-number>
       <input slot="input" type="number" name="e-1" value="10" />
       <label slot="label">Default</label>
-      <span slot="help">This is a help message</span>
     </gux-form-field-number>
   </fieldset>
 
-  <fieldset>
-    <legend>Label Info</legend>
+  <style
+    onload="(function () {
 
-    <gux-form-field-number>
-      <input slot="input" type="number" name="e-1" value="10" />
-      <label slot="label">Default</label>
-      <gux-label-info-beta slot="label-info">
-        <span slot="content">This is some tooltip text</span>
-      </gux-label-info-beta>
-    </gux-form-field-number>
-  </fieldset>
 
-  <fieldset>
-    <legend>Indicator Mark</legend>
-    <a href="gux-form-field-label-indicator.html"
-      >Click here for usage examples</a
-    >
-  </fieldset>
 
-  <fieldset>
-    <legend>Programmatically set value</legend>
+const input = document.querySelector(`#numberField input[slot='input']`);
+  // Get the parent gux-form-field-number component
+  const formField = document.querySelector('#numberField');
 
-    <gux-form-field-number id="p" clearable>
-      <input slot="input" type="number" name="p-1" />
-      <label slot="label">Random number</label>
-    </gux-form-field-number>
+  const announce = document.querySelector('#announce');
 
-    <gux-button-slot>
-      <button
-        type="button"
-        onclick="(function () {
-          const formField = document.getElementById('p');
-          const input = document.querySelector('[name=p-1]');
+  
+  input.addEventListener('focusout', () => {
+  // Check if the error span doesn't already exist to avoid duplicates
+  if (!formField.querySelector(`span[slot='error']`)) {
+    const errorSpan = document.createElement('span');
+    errorSpan.setAttribute('slot', 'error');
+    errorSpan.textContent = 'Error Confirmed';
+    formField.appendChild(errorSpan);
+  }
+});
+ 
 
-          input.value = '';
-          formField.guxForceUpdate();
-        })()"
-      >
-        Clear field
-      </button>
-    </gux-button-slot>
+})()"
+  >
+    .form-container {
+      display: inline-flex;
+      flex-direction: column;
+    }
 
-    <gux-button-slot>
-      <button
-        type="button"
-        onclick="(function () {
-          const randomNumber = Math.floor(Math.random() * 10000);
-          const formField = document.getElementById('p');
-          const input = document.querySelector('[name=p-1]');
+    .width::part(input-section) {
+      inline-size: 108px;
+    }
 
-          input.value = randomNumber;
-          formField.guxForceUpdate();
-        })()"
-      >
-        Set field to random number
-      </button>
-    </gux-button-slot>
-  </fieldset>
+    gux-form-field-number {
+      margin: 10px;
+    }
+  </style>
 </form>
-
-<fieldset>
-  <legend>Setting the input size</legend>
-  <p>
-    To set the size of an input create a class with the desired width and apply
-    this class to the input element.
-  </p>
-
-  <gux-form-field-number class="width" label-position="beside">
-    <input slot="input" type="number" name="e-1" value="10" />
-    <label slot="label">I am long label</label>
-    <span slot="error">Short error message</span>
-  </gux-form-field-number>
-
-  <gux-form-field-number label-position="beside">
-    <input
-      style="inline-size: 200px"
-      slot="input"
-      type="number"
-      name="e-1"
-      value="10"
-    />
-    <label slot="label">I am long label</label>
-    <span slot="error"
-      >This is an error message with a very long text message very very
-      long</span
-    >
-  </gux-form-field-number>
-
-  <gux-form-field-number label-position="beside">
-    <input slot="input" type="number" name="e-1" value="10" />
-    <label slot="label">I am long label</label>
-    <span slot="error"
-      >This is an error message with a very long text message very very
-      long</span
-    >
-  </gux-form-field-number>
-</fieldset>
-
-<style>
-  .form-container {
-    display: inline-flex;
-    flex-direction: column;
-  }
-
-  .width::part(input-section) {
-    inline-size: 108px;
-  }
-
-  gux-form-field-number {
-    margin: 10px;
-  }
-</style>

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
@@ -106,6 +106,12 @@ export class GuxFormFieldNumber {
     this.labelInfo = this.root.querySelector('[slot=label-info]');
     this.hasError = hasSlot(this.root, 'error');
     this.hasHelp = hasSlot(this.root, 'help');
+
+    if (this.hasError) {
+      this.input.setAttribute('aria-invalid', 'true');
+    } else {
+      this.input.removeAttribute('aria-invalid');
+    }
   }
 
   @Listen('keyup')
@@ -157,6 +163,10 @@ export class GuxFormFieldNumber {
     this.labelInfo = this.root.querySelector('[slot=label-info]');
     this.hasError = hasSlot(this.root, 'error');
     this.hasHelp = hasSlot(this.root, 'help');
+
+    if (this.hasError) {
+      this.input.setAttribute('aria-invalid', 'true');
+    }
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -215,9 +225,11 @@ export class GuxFormFieldNumber {
               this.disabled
             )}
           </div>
-          <GuxFormFieldError show={this.hasError}>
-            <slot name="error" />
-          </GuxFormFieldError>
+          <div role="alert" aria-live="assertive">
+            <GuxFormFieldError show={this.hasError}>
+              <slot name="error" />
+            </GuxFormFieldError>
+          </div>
           <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
             <slot name="help" />
           </GuxFormFieldHelp>


### PR DESCRIPTION
Looking for feedback in general on this change and if we should go ahead with doing this change. I did a bit of research around this also and will outline below my thoughts.

If someone could test this change in `NVDA` and `JAWS` that would be appreciated I cannot login to my AWS workspace so I am trying to get it resolved.

Links to research

- https://www.smashingmagazine.com/2023/02/guide-accessible-form-validation/#invalid-fields
- https://bitsofco.de/using-aria-live/
- https://web.dev/learn/forms/accessibility
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid

My first question was should this be something we should be baking into the components or is this something we should just provide guidance on through our documentation. For this PR I implemented a baked in version but I think there may be cons to this approach which I will discuss.

**Types of Validation**
There are different types of validation that can be used and I am unsure this is consistent across the whole genesys cloud platform. The types of validation are,

- Instant Validation - Where the validation occurs on each keypress which would mean that the error would be announced each keypress which would be undesirable and I am sure not a lot of teams use this but just to take note of it.
- Afterwards Validation - Which typically occurs on focus out or on blur which as far as I know is the most used within genesys cloud and would probably be suitable for this use case.
- Submit Validation - Which occurs when you click the submit button. The problem I have with this is if you click submit and 5 fields go to error states what would be announced ( as far as I know its just the first one )  and how will the screen-reader know what to do ?

**Announcing Dynamic Content Changes**
From what I read in the articles and documentation above the correct way to announce dynamic changes in the case of an error dynamically appearing through validation is using `aria-live` which we suspected initially.

**Utilising aria-invalid**
I think we should be utilising `aria-invalid` to identify when invalid data has been passed to the input this is seen as a best practice when used in conjunction with `aria-live`. Voiceover will announce `invalid data` when focused on an input with and error state or invalid data.

**Problems identified**
So I am unsure if this is just a voiceover thing or not but for example if you tab to the first form-field in the example file then than to the next the error will display on the first form-field but the error is not announced by voiceover. But if you are to say tab to the first form-field then click away somewhere else the error will be announced. This is due to how the browser and voiceover works if you tab from one form control to another even if the error shows on the first input it wont be announced as the voiceover screenreader will be processing the new form control instead and will basically ignore the aria-live.