### PR TITLE
feat(styles): Updated styles on modal-legacy and example pages

### DIFF
--- a/packages/genesys-spark-components/src/components/legacy/gux-action-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-action-toast-legacy/example.html
@@ -2,7 +2,7 @@
 
 <div>
   <gux-icon
-    style="color: #6c5619"
+    style="color: var(--gse-semantic-foreground-system-warning-accent)"
     icon-name="alert-warning-triangle"
     decorative="true"
   ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-advanced-dropdown-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-advanced-dropdown-legacy/example.html
@@ -2,7 +2,7 @@
 
 <div>
   <gux-icon
-    style="color: #6c5619"
+    style="color: var(--gse-semantic-foreground-system-warning-accent)"
     icon-name="alert-warning-triangle"
     decorative="true"
   ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-disclosure-button-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-disclosure-button-legacy/example.html
@@ -2,7 +2,7 @@
 
 <div>
   <gux-icon
-    style="color: #6c5619"
+    style="color: var(--gse-semantic-foreground-system-warning-accent)"
     icon-name="alert-warning-triangle"
     decorative="true"
   ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/example.html
@@ -2,7 +2,7 @@
 
 <div>
   <gux-icon
-    style="color: #6c5619"
+    style="color: var(--gse-semantic-foreground-system-warning-accent)"
     icon-name="alert-warning-triangle"
     decorative="true"
   ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/gux-modal-legacy.scss
+++ b/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/gux-modal-legacy.scss
@@ -48,10 +48,7 @@ slot[name='left-align-buttons']::slotted(:not(button, gux-button)) {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(
-      --gse-semantic-foreground-container-highEmphasis
-    ); // TODO: COMUI-2300
-
+    color: var(--gse-semantic-foreground-container-highEmphasis);
     background: var(--gse-ui-modal-shroudColor);
 
     .gux-modal-container {

--- a/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/gux-modal-legacy.scss
+++ b/packages/genesys-spark-components/src/components/legacy/gux-modal-legacy/gux-modal-legacy.scss
@@ -48,7 +48,10 @@ slot[name='left-align-buttons']::slotted(:not(button, gux-button)) {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #2e394c; // TODO: COMUI-2300
+    color: var(
+      --gse-semantic-foreground-container-highEmphasis
+    ); // TODO: COMUI-2300
+
     background: var(--gse-ui-modal-shroudColor);
 
     .gux-modal-container {
@@ -59,7 +62,7 @@ slot[name='left-align-buttons']::slotted(:not(button, gux-button)) {
       justify-content: space-between;
       padding: var(--gse-ui-modal-padding) 0;
       background: var(--gse-ui-modal-backgroundColor);
-      border: 1px solid #b4bccb; // TODO: COMUI-2300
+      border: 1px solid var(--gse-semantic-border-container-edges-default); // TODO: COMUI-2300
       border-radius: var(--gse-ui-modal-borderRadius);
       box-shadow: var(--gse-ui-modal-boxShadow);
 

--- a/packages/genesys-spark-components/src/components/legacy/gux-notification-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-notification-toast-legacy/example.html
@@ -3,7 +3,7 @@
 
   <div>
     <gux-icon
-      style="color: #6c5619"
+      style="color: var(--gse-semantic-foreground-system-warning-accent)"
       icon-name="alert-warning-triangle"
       decorative="true"
     ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-pagination-legacy/example.html
@@ -2,7 +2,7 @@
   <h1>gux-pagination-legacy</h1>
   <div>
     <gux-icon
-      style="color: #6c5619"
+      style="color: var(--gse-semantic-foreground-system-warning-accent)"
       icon-name="alert-warning-triangle"
       decorative="true"
     ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-simple-toast-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-simple-toast-legacy/example.html
@@ -3,7 +3,7 @@
 
   <div>
     <gux-icon
-      style="color: #6c5619"
+      style="color: var(--gse-semantic-foreground-system-warning-accent)"
       icon-name="alert-warning-triangle"
       decorative="true"
     ></gux-icon>

--- a/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/example.html
+++ b/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/example.html
@@ -2,7 +2,7 @@
 
 <div>
   <gux-icon
-    style="color: #6c5619"
+    style="color: var(--gse-semantic-foreground-system-warning-accent)"
     icon-name="alert-warning-triangle"
     decorative="true"
   ></gux-icon>


### PR DESCRIPTION
Updated `gux-modal-legacy` styles to support dark mode.
Updated the color of warning icons in `gux-modal-legacy` and `gux-toast-legacy`