### PR TITLE
fix(dropdown-multi): add afterNextRender when slot content changes

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
@@ -38,6 +38,7 @@ import { afterNextRender } from '@utils/dom/after-next-render';
 
 import translationResources from './i18n/en.json';
 import { GuxFilterTypes } from '../gux-dropdown/gux-dropdown.types';
+import { OnMutation } from '@utils/decorator/on-mutation';
 
 /**
  * @slot - collection of gux-option-multi elements
@@ -87,6 +88,13 @@ export class GuxListboxMulti {
 
   @Prop({ mutable: true })
   hasExactMatch: boolean = false;
+
+  @OnMutation({ childList: true, subtree: true })
+  onMutation(): void {
+    afterNextRender(() => {
+      this.updateOnSlotChange();
+    });
+  }
 
   @Listen('blur')
   onBlur(): void {
@@ -245,7 +253,6 @@ export class GuxListboxMulti {
     this.listboxOptions = (
       Array.from(this.root.children) as HTMLGuxOptionMultiElement[]
     ).filter(element => element.tagName === 'GUX-OPTION-MULTI');
-
     this.internallistboxoptionsupdated.emit();
   }
 
@@ -254,6 +261,7 @@ export class GuxListboxMulti {
       listboxOption.selected = this.getSelectedValues().includes(
         listboxOption.value
       );
+
       if (this.filterType !== 'custom' && this.filterType !== 'none') {
         listboxOption.filtered = !getOptionDefaultSlot(listboxOption)
           ?.textContent.trim()

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.tsx
@@ -188,7 +188,6 @@ export class GuxListbox {
 
   private setListboxOptions(): void {
     this.selectedValues = convertValueToArray(this.value);
-
     this.listboxOptions = getListOptions(this.root);
     this.internallistboxoptionsupdated.emit();
   }


### PR DESCRIPTION
**Steps to reproduce on the live docs**

1. Go to the `Unknown Value Set` dropdown where you add the Jellyfish option.
2. Set the `filter-type` to be `starts-with`
3. Click `Add Jellyfish Option`
4. You should see that the Jellyfish option does not appear in the `listbox-multi` list.



[✅ Closes: COMUI-3609](https://inindca.atlassian.net/browse/COMUI-3609)