### PR TITLE
fix(popover): Add tabindex -1 to gux-popover wrapper div

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-popover/gux-popover.tsx
@@ -244,6 +244,7 @@ export class GuxPopover {
           'gux-popover-wrapper': true
         }}
         data-placement
+        tabindex="-1"
       >
         <div
           ref={(el: HTMLDivElement) => (this.arrowElement = el)}


### PR DESCRIPTION
Add tabindex -1 to gux-popover wrapper div so that it can be programmatically focused. This prevents dismissal on focus out and unexpected relatedTarget values.

✅ Closes: #3747