### PR TITLE
chore(table-toolbar): Fixed layout scaled up

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table-toolbar/gux-table-toolbar.tsx
@@ -87,7 +87,12 @@ export class GuxTableToolbar {
   }
 
   get permanentSlot(): Element | null {
-    return getSlot(this.root, 'permanent-actions');
+    // If permanent actions are not located at the root, then they are assumed to be located within the menu actions.
+    // Permanent actions will be located in the menu actions if the previous display layout was condensed.
+    return (
+      getSlot(this.root, 'permanent-actions') ||
+      getSlot(this.menuActionSlot as HTMLElement, 'permanent-actions')
+    );
   }
 
   get contextualSlot(): Element | null {


### PR DESCRIPTION
✅ Closes: COMUI-3752

This PR fixes an issue where if you're in a condensed display layout and you increase the browser width, the permanent action buttons weren't moving from the menu actions dropdown to the root