### PR TITLE
fix(dropdown): Exclude subtext from selected option

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -445,16 +445,32 @@ export class GuxDropdown {
     }
   }
 
+  private getOptionDefaultText(optionElement: HTMLGuxOptionElement) {
+    // TODO: use getOptionDefaultSlot(option)?.textContent.trim() once Stencil fix for assignedNodes test issue is in (v4.27.2) - COMUI-3655
+    let text = '';
+
+    optionElement.childNodes.forEach(node => {
+      // Only include text nodes or elements without slot="subtext"
+      const addTextContent = () => (text += node.textContent);
+
+      if (node.nodeType === Node.TEXT_NODE) {
+        addTextContent();
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const slot = (node as Element).hasAttribute('slot');
+        const slotValue = (node as Element).getAttribute('slot');
+        if (!slot || slotValue !== 'subtext') {
+          addTextContent();
+        }
+      }
+    });
+
+    return text.trim();
+  }
+
   private renderOption(option: HTMLGuxOptionElement): JSX.Element {
-    let optionText = option.textContent.trim();
-    if (hasSlot(option, 'subtext')) {
-      // TODO: use getOptionDefaultSlot(option)?.textContent.trim() once Stencil fix for assignedNodes test issue is in (v4.27.2) - COMUI-3655
-      const subtext = option.querySelector('[slot=subtext]');
-      optionText = optionText.replace(subtext.textContent.trim(), '');
-    }
     return (
       <gux-truncate ref={el => (this.truncateElement = el)} dir="auto">
-        {optionText}
+        {this.getOptionDefaultText(option)}
       </gux-truncate>
     ) as JSX.Element;
   }
@@ -468,8 +484,7 @@ export class GuxDropdown {
     }
 
     if (hasSlot(iconOption, 'subtext')) {
-      const subtext = iconOption.querySelector('[slot=subtext]');
-      optionText = optionText.replace(subtext.textContent, '');
+      optionText = this.getOptionDefaultText(iconOption);
     }
     return (
       <span

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.e2e.ts
@@ -14,8 +14,8 @@ testWithOptionType(
   'gux-option',
   `
 <gux-option value="a">Ant</gux-option>
-<gux-option value="b">Bear<span slot="subtext">Large</span></gux-option>
-<gux-option value="be">Bee<span slot="subtext">Small</span></gux-option>
+<gux-option value="b">Bear Large<span slot="subtext">Large</span></gux-option>
+<gux-option value="be">Bee Small<span slot="subtext">Small</span></gux-option>
 <gux-option value="c">Cat</gux-option>
 <gux-option value="">None</gux-option>
 `
@@ -25,8 +25,8 @@ testWithOptionType(
   'gux-option-icon',
   `
 <gux-option-icon icon-name="user" value="a">Ant</gux-option-icon>
-<gux-option-icon icon-name="user" value="b">Bear<span slot="subtext">Large</span></gux-option-icon>
-<gux-option-icon icon-name="user" value="be">Bee<span slot="subtext">Small</span></gux-option-icon>
+<gux-option-icon icon-name="user" value="b">Bear Large<span slot="subtext">Large</span></gux-option-icon>
+<gux-option-icon icon-name="user" value="be"><span slot="subtext">Small</span>Bee Small</gux-option-icon>
 <gux-option-icon icon-name="user" value="c">Cat</gux-option-icon>
 <gux-option-icon icon-name="user" value="">None</gux-option-icon>
 `
@@ -253,6 +253,37 @@ function testWithOptionType(optionType: string, listboxContent: string) {
         expect(dropdownSelectedText.outerHTML).toContain('None');
         expect(selectedItem.length).toBe(1);
         expect(selectedItem[0].outerHTML).toContain(listboxItems[4].outerHTML);
+      });
+    });
+
+    describe('selected option text for options with subtext', () => {
+      it('dropdown selected text is correct for option with subtext slotted after option text', async () => {
+        const { page } = await render(nonFilterableDropdown(listboxContent));
+        const dropdownSelectedText = await page.find(`pierce/.gux-field`);
+        expect(dropdownSelectedText.outerHTML).toContain('Select...');
+        await openWithKeyboard(page);
+
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Enter');
+        await expectDropdownToBeClosed(page);
+        await openWithKeyboard(page);
+
+        expect(dropdownSelectedText.textContent).toEqual('Bear Large');
+      });
+
+      it('dropdown selected text is correct for option with subtext slotted before option text', async () => {
+        const { page } = await render(nonFilterableDropdown(listboxContent));
+        const dropdownSelectedText = await page.find(`pierce/.gux-field`);
+        expect(dropdownSelectedText.outerHTML).toContain('Select...');
+        await openWithKeyboard(page);
+
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Enter');
+        await expectDropdownToBeClosed(page);
+        await openWithKeyboard(page);
+
+        expect(dropdownSelectedText.textContent).toEqual('Bee Small');
       });
     });
   });


### PR DESCRIPTION
COMUI-3811

Example to test this out: 
```
<gux-dropdown id="icon-options-dropdown" disabled="false">
    <gux-listbox aria-label="Users">
      <gux-option-icon
        icon-name="user"
        icon-color="var(--gux-blue-60)"
        icon-position="start"
        value="leonardo"
        >Small Leonardo <span slot="subtext">Very Small Leonardo</span></gux-option-icon
      >
      <gux-option-icon
        icon-name="user"
        icon-color="#8452cf"
        value="donatello"
        icon-position="start"
        >Donatello</gux-option-icon
      >
      <gux-option-icon
        icon-name="user"
        icon-color="rgb(234, 11, 11)"
        icon-position="start"
        value="raphael"
        >Raphael</gux-option-icon
      >
      <gux-option-icon
        icon-name="user"
        icon-color="#e08915"
        icon-position="start"
        icon-sr-text="Screenreader information about the icon goes here, if needed"
        value="michelangelo"
        ><span slot="subtext">Very Large Michelangelo</span>Large Michelangelo
      </gux-option-icon>
    </gux-listbox>
  </gux-dropdown>
  <gux-dropdown value="">
    <gux-listbox value="a" aria-label="Animals">
      <gux-option value="a" disabled
        >Ant <span slot="subtext">Very Small</span></gux-option
      >
      <gux-option value="b">Small Bat<span slot="subtext">Bat Y</span></gux-option>
      <!-- <gux-option value="b">Bat<span slot="subtext">Small</span></gux-option> -->
      <gux-option value="c">Cat<span slot="subtext">Medium</span></gux-option>
      <gux-option value="d"><span slot="subtext">Large X</span>Dog Large</gux-option>
    </gux-listbox>
  </gux-dropdown>
```