### PR TITLE
fix(flyout-menu): add animation delay when showing

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-flyout-menu/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-flyout-menu/example.html
@@ -1,4 +1,65 @@
-<h1>gux-flyout-menu</h1>
+<gux-flyout-menu onclick="notify(event)">
+  <span slot="target">Example Target Element</span>
+  <gux-menu slot="menu">
+    <gux-menu-option>Option One</gux-menu-option>
+    <gux-submenu label="Submenu Two">
+      <gux-menu-option>Option One</gux-menu-option>
+      <gux-submenu label="Submenu Two">
+        <gux-menu-option>Option One</gux-menu-option>
+        <gux-menu-option>Option Two</gux-menu-option>
+        <gux-menu-option>Option Three</gux-menu-option>
+      </gux-submenu>
+      <gux-menu-option>Option Three</gux-menu-option>
+    </gux-submenu>
+    <gux-menu-option>Option Three</gux-menu-option>
+    <gux-menu-option>Option Four</gux-menu-option>
+    <gux-submenu label="Submenu Five">
+      <gux-menu-option>Option One</gux-menu-option>
+      <gux-menu-option>Option Two</gux-menu-option>
+      <gux-submenu label="Submenu Three">
+        <gux-menu-option>Option One</gux-menu-option>
+        <gux-submenu label="Submenu Two">
+          <gux-menu-option>Option One</gux-menu-option>
+          <gux-menu-option>Option Two</gux-menu-option>
+          <gux-menu-option>Option Three</gux-menu-option>
+        </gux-submenu>
+        <gux-menu-option>Option Three</gux-menu-option>
+      </gux-submenu>
+    </gux-submenu>
+  </gux-menu>
+</gux-flyout-menu>
+<br />
+<gux-flyout-menu onclick="notify(event)">
+  <span slot="target">Example Target Element</span>
+  <gux-menu slot="menu">
+    <gux-menu-option>Option One</gux-menu-option>
+    <gux-submenu label="Submenu Two">
+      <gux-menu-option>Option One</gux-menu-option>
+      <gux-submenu label="Submenu Two">
+        <gux-menu-option>Option One</gux-menu-option>
+        <gux-menu-option>Option Two</gux-menu-option>
+        <gux-menu-option>Option Three</gux-menu-option>
+      </gux-submenu>
+      <gux-menu-option>Option Three</gux-menu-option>
+    </gux-submenu>
+    <gux-menu-option>Option Three</gux-menu-option>
+    <gux-menu-option>Option Four</gux-menu-option>
+    <gux-submenu label="Submenu Five">
+      <gux-menu-option>Option One</gux-menu-option>
+      <gux-menu-option>Option Two</gux-menu-option>
+      <gux-submenu label="Submenu Three">
+        <gux-menu-option>Option One</gux-menu-option>
+        <gux-submenu label="Submenu Two">
+          <gux-menu-option>Option One</gux-menu-option>
+          <gux-menu-option>Option Two</gux-menu-option>
+          <gux-menu-option>Option Three</gux-menu-option>
+        </gux-submenu>
+        <gux-menu-option>Option Three</gux-menu-option>
+      </gux-submenu>
+    </gux-submenu>
+  </gux-menu>
+</gux-flyout-menu>
+<br />
 <gux-flyout-menu onclick="notify(event)">
   <span slot="target">Example Target Element</span>
   <gux-menu slot="menu">

--- a/packages/genesys-spark-components/src/components/stable/gux-flyout-menu/gux-flyout-menu.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-flyout-menu/gux-flyout-menu.scss
@@ -22,9 +22,14 @@
   display: none;
   border: none;
   border-radius: ui.$gse-ui-menu-borderRadius;
+  opacity: 0;
 
   &.gux-shown {
     display: flex;
+    animation-name: fade-in;
+    animation-duration: 100ms;
+    animation-delay: 250ms;
+    animation-fill-mode: forwards;
   }
 
   .gux-arrow {
@@ -52,5 +57,15 @@
     filter: drop-shadow(
       0 0 4px #{global.$gse-semantic-effects-boxShadow}
     ); // TODO: COMUI-2993 Replace this token with menu-specific token
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
I am still awaiting feedback from UX in relation to the delay timing.

This solution waits `250ms` before showing the flyout menu this is the same wait time for when the flyout menu hides which resolves the issue of overlap when tabbing via keyboard. 

We have a same sort of implementation in the tooltip component where we wait `350ms` before showing the tooltip not that they are related but just to note.

[✅ Closes: COMUI-3571](https://inindca.atlassian.net/browse/COMUI-3571)