### PR TITLE
fix(dropdown): allow to filter dropdown on focus

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.scss
@@ -14,7 +14,7 @@
 }
 
 .gux-field,
-.gux-target-container-expanded {
+.gux-target-container-filterable {
   all: unset;
   box-sizing: border-box;
   display: flex;
@@ -32,14 +32,14 @@
   background-color: ui.$gse-ui-formControl-input-backgroundColor;
 }
 
-.gux-target-container-expanded,
-.gux-target-container-collapsed .gux-field {
+.gux-target-container-filterable,
+.gux-target-container-not-filterable .gux-field {
   padding: ui.$gse-ui-formControl-input-padding;
 }
 
 .gux-error {
-  &.gux-target-container-collapsed .gux-field-button,
-  &.gux-target-container-expanded {
+  &.gux-target-container-not-filterable .gux-field-button,
+  &.gux-target-container-filterable {
     border: ui.$gse-ui-formControl-input-error-border-width
       ui.$gse-ui-formControl-input-error-border-style
       ui.$gse-ui-formControl-input-error-border-color;
@@ -47,8 +47,8 @@
 }
 
 .gux-disabled {
-  &.gux-target-container-collapsed .gux-field-button,
-  &.gux-target-container-expanded {
+  &.gux-target-container-not-filterable .gux-field-button,
+  &.gux-target-container-filterable {
     user-select: none;
     border: ui.$gse-ui-formControl-input-disabled-border-width
       ui.$gse-ui-formControl-input-disabled-border-style
@@ -56,8 +56,8 @@
   }
 }
 
-.gux-target-container-collapsed .gux-field-button:hover,
-.gux-target-container-expanded:hover {
+.gux-target-container-not-filterable .gux-field-button:hover,
+.gux-target-container-filterable:hover {
   border: ui.$gse-ui-formControl-input-hover-border-width
     ui.$gse-ui-formControl-input-hover-border-style
     ui.$gse-ui-formControl-input-hover-border-color;
@@ -137,11 +137,18 @@
   }
 }
 
-.gux-target-container-expanded {
-  border: ui.$gse-ui-formControl-input-active-border-width
-    ui.$gse-ui-formControl-input-active-border-style
-    ui.$gse-ui-formControl-input-active-border-color;
+.gux-target-container-filterable {
+  border: ui.$gse-ui-formControl-input-default-border-width
+    ui.$gse-ui-formControl-input-default-border-style
+    ui.$gse-ui-formControl-input-default-border-color;
   border-radius: ui.$gse-ui-formControl-input-borderRadius;
+
+  &.gux-target-container-filterable-active {
+    border: ui.$gse-ui-formControl-input-active-border-width
+      ui.$gse-ui-formControl-input-active-border-style
+      ui.$gse-ui-formControl-input-active-border-color;
+    border-radius: ui.$gse-ui-formControl-input-borderRadius;
+  }
 
   &:focus-visible {
     @include gux-input-focus-border;
@@ -161,6 +168,11 @@
     }
   }
 
+  .gux-filter-input::selection {
+    color: inherit; /* Keep text color the same */
+    background: transparent; /* Make selection background invisible */
+  }
+
   .gux-field-button {
     inline-size: auto;
     block-size: ui.$gse-ui-formControl-input-contentText-lineHeight;
@@ -176,7 +188,7 @@
   }
 }
 
-.gux-target-container-collapsed .gux-field-button {
+.gux-target-container-not-filterable .gux-field-button {
   border: ui.$gse-ui-formControl-input-default-border-width
     ui.$gse-ui-formControl-input-default-border-style
     ui.$gse-ui-formControl-input-default-border-color;

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -98,6 +98,7 @@ export class GuxDropdown {
   watchExpanded(expanded: boolean) {
     if (!expanded) {
       this.filter = '';
+      this.filterElement.value = '';
     }
   }
 
@@ -492,7 +493,7 @@ export class GuxDropdown {
   }
 
   private renderFilterInputField(): JSX.Element {
-    if (this.expanded && this.isFilterable()) {
+    if (this.isFilterable()) {
       return (
         <div class="gux-field gux-input-field" dir="auto">
           <div class="gux-field-content">
@@ -505,7 +506,6 @@ export class GuxDropdown {
               </div>
               <div class="input-and-dropdown-button">
                 <input
-                  onClick={this.fieldButtonClick.bind(this)}
                   class="gux-filter-input"
                   type="text"
                   aria-label={this.i18n('filterResults')}
@@ -513,8 +513,10 @@ export class GuxDropdown {
                   onInput={this.filterInput.bind(this)}
                   onKeyDown={this.filterKeydown.bind(this)}
                   onKeyUp={this.filterKeyup.bind(this)}
+                  onFocus={() => (this.expanded = true)}
                   disabled={this.disabled}
                 ></input>
+                {this.renderTargetContent()}
               </div>
             </div>
           </div>
@@ -531,10 +533,10 @@ export class GuxDropdown {
     return (
       <div
         class={{
-          'gux-target-container-expanded': this.expanded && this.isFilterable(),
-          'gux-target-container-collapsed': !(
-            this.expanded && this.isFilterable()
-          ),
+          'gux-target-container-filterable': this.isFilterable(),
+          'gux-target-container-filterable-active':
+            this.expanded && this.isFilterable(),
+          'gux-target-container-not-filterable': !this.isFilterable(),
           'gux-error': this.hasError,
           'gux-disabled': this.disabled
         }}
@@ -552,7 +554,7 @@ export class GuxDropdown {
           aria-haspopup="listbox"
           aria-expanded={this.expanded.toString()}
         >
-          {this.renderTargetContent()}
+          {!this.isFilterable() && this.renderTargetContent()}
           {this.renderRadialLoading()}
           <gux-icon
             class={{


### PR DESCRIPTION
Allow to filter dropdown on focus.

Open to opinions on this change, it did take a while to figure out a solution for it.

One noticeable change is if you click to open the filterable dropdown you cannot close it via click on the input you would have to click the arrow icon to close. This sort of makes sense to me as clicking on an input probably should not close the dropdown but I guess it would not be consistent with the existing behaviour we have. I looked online and some searable dropdowns do not close when clicking only when clicking on the arrow button.



[✅ Closes: COMUI-3860](https://inindca.atlassian.net/browse/COMUI-3860)