### PR TITLE
fix(segmented-control-item): Improve NVDA accessibility

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-segmented-control/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-segmented-control/example.html
@@ -14,7 +14,7 @@
         icon-name="fa/align-left-regular"
         decorative
       ></gux-icon>
-      <div slot="text">Align left</div>
+      <span slot="text">Align left</span>
     </gux-segmented-control-item>
 
     <gux-segmented-control-item value="align-center" icon-only>
@@ -23,7 +23,7 @@
         icon-name="fa/align-center-regular"
         decorative
       ></gux-icon>
-      <div slot="text">Align center</div>
+      <span slot="text">Align center</span>
     </gux-segmented-control-item>
 
     <gux-segmented-control-item value="align-right" icon-only disabled>
@@ -32,7 +32,7 @@
         icon-name="fa/align-right-regular"
         decorative
       ></gux-icon>
-      <div slot="text">Align right</div>
+      <span slot="text">Align right</span>
     </gux-segmented-control-item>
 
     <gux-segmented-control-item value="align-justify" icon-only>
@@ -41,7 +41,7 @@
         icon-name="fa/align-justify-regular"
         decorative
       ></gux-icon>
-      <div slot="text">Justify</div>
+      <span slot="text">Justify</span>
     </gux-segmented-control-item>
   </gux-segmented-control-beta>
 </div>
@@ -55,19 +55,19 @@
     oninput="notify(event)"
   >
     <gux-segmented-control-item value="month">
-      <div slot="text">Month</div>
+      <span slot="text">Month</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="week">
-      <div slot="text">Week</div>
+      <span slot="text">Week</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="day">
-      <div slot="text">Day</div>
+      <span slot="text">Day</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="hour" disabled>
-      <div slot="text">Hour</div>
+      <span slot="text">Hour</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="minute">
-      <div slot="text">Minute</div>
+      <span slot="text">Minute</span>
     </gux-segmented-control-item>
   </gux-segmented-control-beta>
 </div>
@@ -82,12 +82,12 @@
   >
     <gux-segmented-control-item value="collapse">
       <gux-icon slot="icon" icon-name="collapse" decorative></gux-icon>
-      <div slot="text">Collapse</div>
+      <span slot="text">Collapse</span>
     </gux-segmented-control-item>
 
     <gux-segmented-control-item value="expand">
       <gux-icon slot="icon" icon-name="expand" decorative></gux-icon>
-      <div slot="text">Expand</div>
+      <span slot="text">Expand</span>
     </gux-segmented-control-item>
   </gux-segmented-control-beta>
 </div>
@@ -102,19 +102,19 @@
     oninput="notify(event)"
   >
     <gux-segmented-control-item value="month">
-      <div slot="text">Month</div>
+      <span slot="text">Month</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="week">
-      <div slot="text">Week</div>
+      <span slot="text">Week</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="day">
-      <div slot="text">Day</div>
+      <span slot="text">Day</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="hour" disabled>
-      <div slot="text">Hour</div>
+      <span slot="text">Hour</span>
     </gux-segmented-control-item>
     <gux-segmented-control-item value="minute">
-      <div slot="text">Minute</div>
+      <span slot="text">Minute</span>
     </gux-segmented-control-item>
   </gux-segmented-control-beta>
 </div>
@@ -123,19 +123,19 @@
 
 <gux-segmented-control-beta id="get-value" value="day">
   <gux-segmented-control-item value="month">
-    <div slot="text">Month</div>
+    <span slot="text">Month</span>
   </gux-segmented-control-item>
   <gux-segmented-control-item value="week">
-    <div slot="text">Week</div>
+    <span slot="text">Week</span>
   </gux-segmented-control-item>
   <gux-segmented-control-item value="day">
-    <div slot="text">Day</div>
+    <span slot="text">Day</span>
   </gux-segmented-control-item>
   <gux-segmented-control-item value="hour" disabled>
-    <div slot="text">Hour</div>
+    <span slot="text">Hour</span>
   </gux-segmented-control-item>
   <gux-segmented-control-item value="minute">
-    <div slot="text">Minute</div>
+    <span slot="text">Minute</span>
   </gux-segmented-control-item>
 </gux-segmented-control-beta>
 

--- a/packages/genesys-spark-components/src/components/beta/gux-segmented-control/gux-segmented-control-item/gux-segmented-control-item.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-segmented-control/gux-segmented-control-item/gux-segmented-control-item.tsx
@@ -118,14 +118,14 @@ export class GuxSegmentedControlItem {
           disabled={this.disabled || this.hasDisabledParent()}
         >
           {this.renderIconSlot()}
-          <div
+          <span
             class={{
               'gux-text': true,
               'gux-icon-only': this.iconOnly
             }}
           >
             <slot name="text" />
-          </div>
+          </span>
         </button>
         {this.renderTooltip()}
       </div>

--- a/packages/genesys-spark-components/src/components/beta/gux-segmented-control/tests/__snapshots__/gux-segmented-control.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-segmented-control/tests/__snapshots__/gux-segmented-control.spec.ts.snap
@@ -9,9 +9,9 @@ exports[`gux-segmented-control-beta #render should render as expected 1`] = `
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container gux-start">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -23,9 +23,9 @@ exports[`gux-segmented-control-beta #render should render as expected 1`] = `
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -37,9 +37,9 @@ exports[`gux-segmented-control-beta #render should render as expected 1`] = `
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -51,9 +51,9 @@ exports[`gux-segmented-control-beta #render should render as expected 1`] = `
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" disabled="" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -65,9 +65,9 @@ exports[`gux-segmented-control-beta #render should render as expected 1`] = `
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container gux-end">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -87,9 +87,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container gux-start">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -101,9 +101,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -115,9 +115,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -129,9 +129,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container">
         <button aria-current="false" class="gux-segmented-control-item" disabled="" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -143,9 +143,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container gux-end">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>
@@ -157,9 +157,9 @@ exports[`gux-segmented-control-beta onSlotchange should set selected items as ex
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-container gux-end">
         <button aria-current="false" class="gux-segmented-control-item" type="button">
-          <div class="gux-text">
+          <span class="gux-text">
             <slot name="text"></slot>
-          </div>
+          </span>
         </button>
       </div>
     </template>


### PR DESCRIPTION
COMUI-3652

This is an imperfect solution to an issue that's likely caused by  this issue [Possible issue with NVDA support for Shadow DOM in Chromium](https://github.com/nvaccess/nvda/issues/17845). Open to other ideas but this is the only one I've found that works consistently. 