### PR TITLE
fix(popover-beta): add method to focus popover

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-popover-beta/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-popover-beta/example.html
@@ -27,7 +27,52 @@
   </div>
 </div>
 
-<style>
+<h2>Dynamic Popover with guxFocusPopover()</h2>
+<div>
+  <gux-button id="dynamic-trigger">Show Dynamic Popover</gux-button>
+  <div id="dynamic-popover-container"></div>
+</div>
+
+<style
+  onload="(function () {
+  const dynamicTrigger = document.getElementById('dynamic-trigger');
+  const container = document.getElementById('dynamic-popover-container');
+    
+
+  dynamicTrigger.addEventListener('click', function() {
+      const popover = document.createElement('gux-popover-beta');
+      popover.id = 'dynamic-popover';
+      popover.setAttribute('position', 'bottom');
+      popover.setAttribute('for', 'dynamic-trigger');
+      popover.setAttribute('is-open', '');
+      
+      const title = document.createElement('span');
+      title.setAttribute('slot', 'title');
+      title.textContent = 'Dynamic Popover';
+      
+      const content = document.createElement('div');
+      const text = document.createElement('p');
+      text.textContent = 'This popover was created dynamically and focused using guxFocusPopover()';
+      
+      const button = document.createElement('gux-button');
+      button.setAttribute('autofocus', '');
+      button.textContent = 'Focused Button';
+      
+      content.appendChild(text);
+      content.appendChild(button);
+      popover.appendChild(title);
+      popover.appendChild(content);
+      container.appendChild(popover);
+      
+
+      popover.guxFocusPopover();
+     
+    });
+
+
+
+  })()"
+>
   .scroll-container {
     inline-size: 900px;
     block-size: 400px;

--- a/packages/genesys-spark-components/src/components/beta/gux-popover-beta/gux-popover.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popover-beta/gux-popover.tsx
@@ -133,6 +133,11 @@ export class GuxPopover {
     this.dismiss();
   }
 
+  @Method()
+  async guxFocusPopover(): Promise<void> {
+    this.focusPopup();
+  }
+
   get titleSlot(): Element | null {
     return getSlot(this.root, 'title');
   }

--- a/packages/genesys-spark-components/src/components/beta/gux-popover-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-popover-beta/readme.md
@@ -40,6 +40,16 @@ Type: `Promise<void>`
 
 
 
+### `guxFocusPopover() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## Slots
 


### PR DESCRIPTION
From my understanding of the ticket they have a `for` element which when they press the enter key renders the popover but the `autofocus` will not work due to the fact that the `gux-popover-beta` wont have been rendered therefore missing the `keydownHandler` that we have within the component.

Let me know if there is any drawbacks to this choice.

[✅ Closes: COMUI-3916](https://inindca.atlassian.net/browse/COMUI-3916)