### PR TITLE
fix(copy-to-clipboard): Add longer error message

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/i18n/en.json
+++ b/packages/genesys-spark-components/src/components/stable/gux-copy-to-clipboard/i18n/en.json
@@ -1,5 +1,5 @@
 {
   "clickToCopy": "Click to Copy",
   "copySuccess": "Copied to Clipboard",
-  "copyFailure": "Error. Please Try Again."
+  "copyFailure": "Copy failed. Please try again."
 }

--- a/packages/genesys-spark-components/src/i18n/translations/en.json
+++ b/packages/genesys-spark-components/src/i18n/translations/en.json
@@ -62,7 +62,7 @@
   "gux-copy-to-clipboard": {
     "clickToCopy": "Click to Copy",
     "copySuccess": "Copied to Clipboard",
-    "copyFailure": "Error. Please Try Again."
+    "copyFailure": "Copy failed. Please try again."
   },
   "gux-create-option": {
     "createCustomOptionInstructions": ", select to create a new custom option",


### PR DESCRIPTION
COMUI-3311


To test you can run this in the console and the click to see the error: 
`  navigator.clipboard.writeText = () => Promise.reject(new Error('Clipboard access denied'));`