### PR TITLE
chore(other): Display non-component examples in docs

### DIFF
--- a/packages/genesys-spark/scripts/generate-component-data.mjs
+++ b/packages/genesys-spark/scripts/generate-component-data.mjs
@@ -32,7 +32,7 @@ function generateComponentSpec() {
   const styleExamples = globSync(styleExampleGlob);
   const stylesSpec = styleExamples.reduce((spec, examplePath) => {
     const name = path.basename(examplePath, '.html');
-    spec[name] = { styles: true };
+    spec[name] = { tag: name, styles: true };
     return spec;
   }, {});
 

--- a/web-apps/genesys-spark-examples/src/component-listing/app.js
+++ b/web-apps/genesys-spark-examples/src/component-listing/app.js
@@ -13,8 +13,8 @@ export async function bootstrap() {
   ]);
 
   const components = Object.values(componentSpecs)
-    .filter(component => component.example)
-    .sort((a, b) => a.tag.localeCompare(b.tag));
+    .filter(component => component.example || !component.tag.includes('gux-'))
+    .sort((a, b) => shortName(a.tag).localeCompare(shortName(b.tag)));
 
   document.body.appendChild(
     toHTML(`


### PR DESCRIPTION
✅ Closes: n/a

Focus, z-index pages etc aren't showing in the docs site. 