### PR TITLE
fix(context-menu): fix cropped outline

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-list/list-item-default.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-list/list-item-default.scss
@@ -37,7 +37,9 @@
     word-wrap: break-word;
     cursor: pointer;
     outline: none;
-    outline-offset: calc(#{ui.$gse-ui-menu-option-focus-border-width} * -1);
+    outline-offset: calc(
+      #{ui.$gse-ui-menu-option-focus-border-width} * -1
+    ) !important;
     background-color: ui.$gse-ui-menu-option-default-backgroundColor;
     border: none;
 


### PR DESCRIPTION
There's an issue in the docs site but not present locally where the rule for outline-offset is getting overwritten by an incorrect value. 
<img width="299" height="248" alt="Screenshot 2025-07-16 at 12 55 42" src="https://github.com/user-attachments/assets/8d48f7ca-992b-456e-bb2f-b39c991a2927" />
