### PR TITLE
fix(switch-legacy): add aria-current to selected item

### DIFF
--- a/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/gux-switch-item/gux-switch-item.tsx
+++ b/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/gux-switch-item/gux-switch-item.tsx
@@ -29,7 +29,12 @@ export class GuxSwitchItem {
   render(): JSX.Element {
     return (
       <Host class={{ 'gux-selected': this.selected }}>
-        <button type="button" class="gux-switch-item" disabled={this.disabled}>
+        <button
+          aria-current={this.selected.toString()}
+          type="button"
+          class="gux-switch-item"
+          disabled={this.disabled}
+        >
           <slot />
         </button>
       </Host>

--- a/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/tests/__snapshots__/gux-switch.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/legacy/gux-switch-legacy/tests/__snapshots__/gux-switch.spec.ts.snap
@@ -7,31 +7,31 @@ exports[`gux-switch-legacy #render should render component as expected (1) 1`] =
   </template>
   <gux-switch-item value="month">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Month
     </button>
   </gux-switch-item>
   <gux-switch-item value="week">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Week
     </button>
   </gux-switch-item>
   <gux-switch-item value="day">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Day
     </button>
   </gux-switch-item>
   <gux-switch-item disabled="" value="hour">
     <!---->
-    <button class="gux-switch-item" disabled="" type="button">
+    <button aria-current="false" class="gux-switch-item" disabled="" type="button">
       Hour
     </button>
   </gux-switch-item>
   <gux-switch-item value="minute">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Minute
     </button>
   </gux-switch-item>
@@ -45,37 +45,37 @@ exports[`gux-switch-legacy onSlotchange should set selected items as expected 1`
   </template>
   <gux-switch-item value="month">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Month
     </button>
   </gux-switch-item>
   <gux-switch-item value="week">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Week
     </button>
   </gux-switch-item>
   <gux-switch-item value="day">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Day
     </button>
   </gux-switch-item>
   <gux-switch-item disabled="" value="hour">
     <!---->
-    <button class="gux-switch-item" disabled="" type="button">
+    <button aria-current="false" class="gux-switch-item" disabled="" type="button">
       Hour
     </button>
   </gux-switch-item>
   <gux-switch-item value="minute">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Minute
     </button>
   </gux-switch-item>
   <gux-switch-item value="second">
     <!---->
-    <button class="gux-switch-item" type="button">
+    <button aria-current="false" class="gux-switch-item" type="button">
       Second
     </button>
   </gux-switch-item>


### PR DESCRIPTION
Even though this is a legacy component this is an accessibility fix that adds `aria-current` to the selected item

How do I update the snapshots locally? The npm command `npm run test.update-snapshot` in `genesys-spark-components` was not working