### PR TITLE
feat(row-select): Added new label prop

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-table/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/example.html
@@ -984,6 +984,50 @@
   </table>
 </gux-table>
 
+<h2>
+  Data table with custom label used in gux-row-select (the custom label will be
+  read by the screenreader)
+</h2>
+<gux-table style="block-size: 150px">
+  <table slot="data">
+    <thead>
+      <tr>
+        <th>
+          <gux-table-select-menu>
+            <gux-all-row-select></gux-all-row-select>
+            <gux-list slot="select-menu-options">
+              <gux-list-item onclick="notify(event)">
+                All on page
+              </gux-list-item>
+              <gux-list-item onclick="notify(event)"> None </gux-list-item>
+              <gux-list-item onclick="notify(event)">
+                Bring selected to top
+              </gux-list-item>
+            </gux-list>
+          </gux-table-select-menu>
+        </th>
+        <th>Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr data-row-id="person-id-1">
+        <td>
+          <gux-row-select label="Please select a person"></gux-row-select>
+        </td>
+        <td>John</td>
+      </tr>
+      <tr data-row-id="person-id-2">
+        <td>
+          <gux-row-select
+            label="Please select a second person"
+          ></gux-row-select>
+        </td>
+        <td>Jane</td>
+      </tr>
+    </tbody>
+  </table>
+</gux-table>
+
 <style
   onload="(function () {
     function ascending( a, b ) {

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/gux-row-select.tsx
@@ -32,6 +32,9 @@ export class GuxRowSelect {
   @Prop()
   disabled: boolean;
 
+  @Prop()
+  label: string;
+
   @Event()
   internalrowselectchange: EventEmitter;
 
@@ -68,7 +71,7 @@ export class GuxRowSelect {
         />
         <label slot="label" htmlFor={this.id}>
           &#8203;
-          <span>{this.i18n('selectTableRow')}</span>
+          <span>{this.label ? this.label : this.i18n('selectTableRow')}</span>
         </label>
       </gux-form-field-checkbox>
     ) as JSX.Element;

--- a/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-table/gux-row-select/readme.md
@@ -10,6 +10,7 @@
 | Property   | Attribute  | Description | Type      | Default     |
 | ---------- | ---------- | ----------- | --------- | ----------- |
 | `disabled` | `disabled` |             | `boolean` | `undefined` |
+| `label`    | `label`    |             | `string`  | `undefined` |
 | `selected` | `selected` |             | `boolean` | `false`     |
 
 


### PR DESCRIPTION
✅ Closes: COMUI-3913

This PR adds a new label API field to the gux-row-select component. If this new label prop is set then screenreaders will read out this label text instead of the default text that's currently being used. Does the name of this API property make sense or would `labelText` or `customLabel` or something else make more sense?

Also, does anyone know if there's another step I need to take to get this new API field in the next release? I thought I remember some other release file I have to modify when API changes are made but wanted to confirm with you all.