### PR TITLE
fix(dropdown-multi): allow to filter dropdown-multi on focus

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.scss
@@ -12,8 +12,8 @@
 }
 
 .gux-error {
-  &.gux-target-container-collapsed .gux-field-button,
-  &.gux-target-container-expanded {
+  &.gux-target-container-not-filterable .gux-field-button,
+  &.gux-target-container-filterable {
     border: ui.$gse-ui-formControl-input-error-border-width
       ui.$gse-ui-formControl-input-error-border-style
       ui.$gse-ui-formControl-input-error-border-color;
@@ -21,8 +21,8 @@
 }
 
 .gux-disabled {
-  &.gux-target-container-collapsed .gux-field-button,
-  &.gux-target-container-expanded {
+  &.gux-target-container-not-filterable .gux-field-button,
+  &.gux-target-container-filterable {
     user-select: none;
     border: ui.$gse-ui-formControl-input-disabled-border-width
       ui.$gse-ui-formControl-input-disabled-border-style
@@ -31,7 +31,7 @@
 }
 
 .gux-field,
-.gux-target-container-expanded {
+.gux-target-container-filterable {
   all: unset;
   box-sizing: border-box;
   display: flex;
@@ -49,13 +49,13 @@
   background-color: ui.$gse-ui-formControl-input-backgroundColor;
 }
 
-.gux-target-container-expanded,
-.gux-target-container-collapsed .gux-field {
+.gux-target-container-filterable,
+.gux-target-container-not-filterable .gux-field {
   padding: ui.$gse-ui-formControl-input-padding;
 }
 
-.gux-target-container-collapsed .gux-field-button:hover,
-.gux-target-container-expanded:hover {
+.gux-target-container-not-filterable .gux-field-button:hover,
+.gux-target-container-filterable:hover {
   border: ui.$gse-ui-formControl-input-hover-border-width
     ui.$gse-ui-formControl-input-hover-border-style
     ui.$gse-ui-formControl-input-hover-border-color;
@@ -85,7 +85,6 @@
       order: 0;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
 
       .gux-sr-only {
         @include mixins.gux-sr-only-clip;
@@ -140,10 +139,10 @@
   }
 }
 
-.gux-target-container-expanded {
-  border: ui.$gse-ui-formControl-input-active-border-width
-    ui.$gse-ui-formControl-input-active-border-style
-    ui.$gse-ui-formControl-input-active-border-color;
+.gux-target-container-filterable {
+  border: ui.$gse-ui-formControl-input-default-border-width
+    ui.$gse-ui-formControl-input-default-border-style
+    ui.$gse-ui-formControl-input-default-border-color;
   border-radius: ui.$gse-ui-formControl-input-borderRadius;
 
   &:focus-visible {
@@ -152,6 +151,13 @@
 
   &:focus-within:has(:focus-visible) {
     @include focus.gux-focus-ring;
+  }
+
+  &.gux-target-container-filterable-active {
+    border: ui.$gse-ui-formControl-input-active-border-width
+      ui.$gse-ui-formControl-input-active-border-style
+      ui.$gse-ui-formControl-input-active-border-color;
+    border-radius: ui.$gse-ui-formControl-input-borderRadius;
   }
 
   .gux-filter-input {
@@ -179,7 +185,7 @@
   }
 }
 
-.gux-target-container-collapsed .gux-field-button {
+.gux-target-container-not-filterable .gux-field-button {
   border: ui.$gse-ui-formControl-input-default-border-width
     ui.$gse-ui-formControl-input-default-border-style
     ui.$gse-ui-formControl-input-default-border-color;
@@ -192,6 +198,10 @@
   &:focus-within:has(:focus-visible) {
     @include focus.gux-focus-ring;
   }
+}
+
+.gux-target-container-not-filterable .gux-field-content .gux-placeholder {
+  white-space: pre;
 }
 
 .gux-listbox-container {

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
@@ -151,6 +151,7 @@ export class GuxDropdownMulti {
 
     if (!expanded) {
       this.textInput = '';
+      this.textInputElement.value = '';
     }
   }
 
@@ -277,6 +278,13 @@ export class GuxDropdownMulti {
   @Listen('focusin')
   onFocusin(event: FocusEvent): void {
     this.stopPropagationOfInternalFocusEvents(event);
+
+    if (
+      this.isFilterable &&
+      !this.root.contains(event?.relatedTarget as Node)
+    ) {
+      this.textInputElement.focus();
+    }
   }
 
   @OnClickOutside({ triggerEvents: 'mousedown' })
@@ -548,7 +556,7 @@ export class GuxDropdownMulti {
   }
 
   private renderFilterInputField(): JSX.Element {
-    if (this.expanded && this.hasTextInput()) {
+    if (this.hasTextInput()) {
       return (
         <div class="gux-field gux-input-field">
           <div class="gux-field-content">
@@ -574,8 +582,10 @@ export class GuxDropdownMulti {
                   onInput={this.filterInput.bind(this)}
                   onKeyDown={this.filterKeydown.bind(this)}
                   onKeyUp={this.filterKeyup.bind(this)}
+                  onFocus={() => (this.expanded = true)}
                   disabled={this.disabled}
                 ></input>
+                {this.renderTargetContent()}
               </div>
             </div>
           </div>
@@ -597,10 +607,10 @@ export class GuxDropdownMulti {
       <div
         class={{
           'gux-target-container': true,
-          'gux-target-container-expanded': this.expanded && this.hasTextInput(),
-          'gux-target-container-collapsed': !(
-            this.expanded && this.hasTextInput()
-          ),
+          'gux-target-container-filterable': this.hasTextInput(),
+          'gux-target-container-filterable-active':
+            this.expanded && this.hasTextInput(),
+          'gux-target-container-not-filterable': !this.hasTextInput(),
           'gux-error': this.hasError,
           'gux-disabled': this.disabled
         }}
@@ -616,7 +626,7 @@ export class GuxDropdownMulti {
           aria-haspopup="listbox"
           aria-expanded={this.expanded.toString()}
         >
-          {this.renderTargetContent()}
+          {!this.hasTextInput() && this.renderTargetContent()}
           {this.renderTag()}
           {this.renderRadialLoading()}
           <gux-icon

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/tests/__snapshots__/gux-dropdown-multi.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/tests/__snapshots__/gux-dropdown-multi.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`gux-dropdown #render should render as expected 1`] = `
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="gux-dropdown-container">
       <gux-popup>
-        <div class="gux-target-container gux-target-container-collapsed" slot="target">
+        <div class="gux-target-container gux-target-container-not-filterable" slot="target">
           <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
             <div class="gux-field-content">
               <div class="gux-placeholder">

--- a/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help multi select
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -145,7 +145,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help multi select
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -258,7 +258,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render help should rende
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -369,7 +369,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -477,7 +477,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup disabled="">
-          <div class="gux-disabled gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-disabled gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" disabled="" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -585,7 +585,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render input attributes 
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -693,7 +693,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -801,7 +801,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -909,7 +909,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -1017,7 +1017,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render label-position sh
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -1125,7 +1125,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render multi indicator m
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -1233,7 +1233,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render multi indicator m
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -1341,7 +1341,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render multi indicator m
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">
@@ -1449,7 +1449,7 @@ exports[`gux-form-field-dropdown multi select dropdown #render multi label-info 
     <template shadowrootmode="open" shadowrootdelegatesfocus>
       <div class="gux-dropdown-container">
         <gux-popup>
-          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+          <div class="gux-target-container gux-target-container-not-filterable" slot="target">
             <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
               <div class="gux-field-content">
                 <div class="gux-placeholder">


### PR DESCRIPTION
allow to filter dropdown-multi on focus

This is the same fix as was done in the below PR. Basically when you focus on the dropdown via keyboard it will allow you to immediately start typing. 

https://github.com/MyPureCloud/genesys-spark/pull/1165/files

✅ Closes: [COMUI-3860](https://inindca.atlassian.net/browse/COMUI-3860)

[COMUI-3860]: https://inindca.atlassian.net/browse/COMUI-3860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ