### PR TITLE
fix(datepicker): allow for a narrower width than the default to be applied

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.scss
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.scss
@@ -116,6 +116,7 @@
             #{ui.$gse-ui-calendarMenu-day-input-width} -
               #{ui.$gse-ui-icon-small-size}
           );
+          inline-size: 100%;
           padding: 0;
           overflow: hidden;
           font-family: ui.$gse-ui-formControl-input-contentText-fontFamily;


### PR DESCRIPTION
Not perfect but is a quick improvement.
Resolves this issue:

<img width="413" height="499" alt="image" src="https://github.com/user-attachments/assets/ecf09859-4a09-45aa-9d40-a867aa388d9c" />
