### PR TITLE
feat(visualization-beta): Add aria-label support to visualization-beta component

### DIFF
--- a/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/example.html
+++ b/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/example.html
@@ -54,7 +54,11 @@
 <gux-visualization-beta id="chart-6"> </gux-visualization-beta>
 
 <h2>Line Chart with Tooltips</h2>
-<gux-visualization-beta id="chart-7"> </gux-visualization-beta>
+<gux-visualization-beta
+  id="chart-7"
+  screenreader-description="Line chart showing daily max temperature from January 1, 2012 through December 31, 2025."
+>
+</gux-visualization-beta>
 
 <style
   onload="(function() {

--- a/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.tsx
+++ b/packages/genesys-spark-chart-components/src/components/beta/gux-visualization/gux-visualization.tsx
@@ -62,6 +62,10 @@ export class GuxVisualization {
   @Prop()
   embedOptions: EmbedOptions;
 
+  // Adds an aria-label to the SVG element for screen readers
+  @Prop()
+  screenreaderDescription: string;
+
   componentWillLoad(): void {
     trackComponent(this.root);
   }
@@ -106,6 +110,14 @@ export class GuxVisualization {
       result.view.addSignalListener('chartClick', (name, value) =>
         this.handleChartClick(name, value)
       );
+
+      // Set aria-label on the SVG if screenreaderDescription is provided
+      if (this.screenreaderDescription) {
+        const svgElement = this.chartContainer.querySelector('svg');
+        if (svgElement) {
+          svgElement.setAttribute('aria-label', this.screenreaderDescription);
+        }
+      }
     });
   }
 


### PR DESCRIPTION
Vega supports a 'description' which adds an aria-label to the div; that doesn't work for screen readers and instead we need to apply this to the SVG. This will allow users to provide a description that directs them to where they can find the corresponding data or provide a description of what's being visualized. https://www.w3.org/WAI/tutorials/images/complex/ 

✅ Closes: ENGAGEUI-10345