### PR TITLE
refactor(other): remove disabled=false from example docs

### DIFF
--- a/packages/genesys-spark-components/documentation/COMPONENT_DESIGN.md
+++ b/packages/genesys-spark-components/documentation/COMPONENT_DESIGN.md
@@ -117,6 +117,4 @@ class may remove it from the list. Instead, add a `gux-` prefixed attribute, and
 
 #### 1. Boolean Attributes
 
-Unlike native elements, Stencil will parse a boolean attribute set to `"false"` as `false` (native elements treat any
-presence of the attribute as true). Unfortunately, there's not much we can do but live with this, as trying to work
-around it would be error-prone and add unnecessary complexity.
+When using boolean attributes on the components, adhere to the HTML specification rather than the Stencil JS specification for setting boolean attributes on components. For example, in Stencil JS, setting `disabled="false"` on a component explicitly sets the property to `false`. However, in the HTML spec, boolean attributes are considered `true` when present, regardless of their string value, which can lead to unexpected behavior in browsers and assistive technologies like NVDA that rely on the HTML spec. To ensure compatibility and correct behavior, omit boolean attributes entirely when they should be `false`, following standard HTML practices.

--- a/packages/genesys-spark-components/src/components/beta/gux-phone-input/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-phone-input/example.html
@@ -44,7 +44,7 @@
     </div>
     <div class="flex-example">
       <h4 class="flex-header">false</h4>
-      <gux-phone-input-beta disabled="false"></gux-phone-input-beta>
+      <gux-phone-input-beta></gux-phone-input-beta>
     </div>
   </div>
 </section>

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/example.html
@@ -451,7 +451,7 @@
 
   <h3>Icon Options</h3>
 
-  <gux-dropdown id="icon-options-dropdown" disabled="false">
+  <gux-dropdown id="icon-options-dropdown">
     <gux-listbox aria-label="Users">
       <gux-option-icon
         icon-name="user"


### PR DESCRIPTION
**Question**
Where do people think is the best place is to call out this difference? In the example pages of the components or in the readme  of `genesys-spark-components` or somewhere else ?

✅ Closes: COMUI-4128