### PR TITLE
fix(prompt-input-beta): add vertical scroll state

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-prompt-input/gux-prompt-input-beta.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-prompt-input/gux-prompt-input-beta.scss
@@ -21,6 +21,38 @@
       global.$gse-semantic-foreground-interactive-secondary-active;
   }
 
+  .gux-grow-wrap {
+    display: grid;
+    inline-size: 100%;
+    min-block-size: ui.$gse-ui-promptInput-simple-label-minHeight;
+    min-block-size: 0;
+    max-block-size: ui.$gse-ui-promptInput-simple-label-maxHeight;
+    overflow: hidden auto;
+
+    &::after {
+      visibility: hidden;
+      grid-area: 1 / 1 / 2 / 2;
+      padding: 0;
+      margin: 0;
+      font-family: global.$gse-semantic-theme-fontFamily-body;
+      font-size: global.$gse-core-fontSize-sm;
+      font-weight: global.$gse-core-fontWeight-regular;
+      line-height: global.$gse-core-lineHeight-sm;
+      color: global.$gse-semantic-foreground-formControl-textInput-placeholder;
+      overflow-wrap: break-word;
+      white-space: pre-wrap;
+      content: attr(data-replicated-value) ' ';
+      border: 0;
+    }
+
+    > textarea {
+      grid-area: 1 / 1 / 2 / 2;
+      overflow: hidden;
+      overflow-wrap: break-word;
+      resize: none;
+    }
+  }
+
   .gux-input {
     inline-size: 100%;
     font-family: global.$gse-semantic-theme-fontFamily-body;

--- a/packages/genesys-spark-components/src/components/beta/gux-prompt-input/gux-prompt-input-beta.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-prompt-input/gux-prompt-input-beta.tsx
@@ -36,7 +36,7 @@ export class GuxPromptInputBeta {
   @State()
   hasInputText: boolean = false;
 
-  private inputElement: HTMLInputElement;
+  private inputElement: HTMLTextAreaElement;
   private i18n: GetI18nValue;
 
   /**
@@ -82,8 +82,10 @@ export class GuxPromptInputBeta {
     this.isGenerating = false;
   }
 
-  private keyUp(): void {
+  private handleInput(): void {
     this.hasInputText = this.inputElement.value?.length > 0;
+    this.inputElement.parentElement.dataset.replicatedValue =
+      this.inputElement.value;
   }
 
   private renderSubmitButton(): JSX.Element {
@@ -130,14 +132,16 @@ export class GuxPromptInputBeta {
     return (
       <Host>
         <div class="gux-input-container">
-          <input
-            class="gux-input"
-            ref={el => (this.inputElement = el)}
-            placeholder={this.placeholder || this.i18n('inputPlaceholder')}
-            onKeyUp={this.keyUp.bind(this)}
-            data-testid="prompt-input"
-          ></input>
-
+          <div class="gux-grow-wrap">
+            <textarea
+              rows={1}
+              class="gux-input"
+              ref={el => (this.inputElement = el)}
+              placeholder={this.placeholder || this.i18n('inputPlaceholder')}
+              onInput={this.handleInput.bind(this)}
+              data-testid="prompt-input"
+            ></textarea>
+          </div>
           {this.isGenerating
             ? this.renderStopButton()
             : this.renderSubmitButton()}

--- a/packages/genesys-spark-components/src/components/beta/gux-prompt-input/tests/__snapshots__/gux-prompt-input-beta.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-prompt-input/tests/__snapshots__/gux-prompt-input-beta.spec.ts.snap
@@ -4,7 +4,8 @@ exports[`gux-prompt-input-beta should render component as expected 1`] = `
 <gux-prompt-input-beta placeholder="Ask Genesys AI">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="gux-input-container">
-      <input class="gux-input" data-testid="prompt-input" placeholder="Ask Genesys AI">
+      <div class="gux-grow-wrap"><textarea class="gux-input" data-testid="prompt-input" placeholder="Ask Genesys AI" rows="1"></textarea>
+      </div>
       <gux-button-slot accent="primary">
         <button class="gux-generate" data-testid="generate-button" disabled="" title="Generate Genesys AI text" type="button">
           <gux-icon decorative="" icon-name="fa/arrow-up-regular" size="small"></gux-icon>


### PR DESCRIPTION
This is to allow the `text-area` to grow vertically as content is added until a max-blocksize of 200px. This is currently the only solution to allow the text-area to grow with content (https://codepen.io/chriscoyier/pen/XWKEVLy).

I have created a ticket to add the `field-sizing` css property once stabilised in browsers which will replace the current solutions :  https://inindca.atlassian.net/browse/COMUI-4148

✅ Closes: COMUI-4143