### PR TITLE
fix(loading-message): update examples to convey better descriptions to screenreader

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-loading-message/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-loading-message/example.html
@@ -7,13 +7,15 @@
 </h3>
 <div class="resizing">
   <gux-loading-message>
-    <div slot="primary-message">The content is loading...</div>
-    <div slot="additional-guidance">Thank you for waiting.</div>
+    <div slot="primary-message">Processing your data...</div>
+    <div slot="additional-guidance">
+      This may take a few moments. Please stay on this page.
+    </div>
     <gux-radial-progress
       slot="progress"
       value="1"
       max="10"
-      screenreader-text="loading"
+      screenreader-text="Loading is 10% complete"
     ></gux-radial-progress>
   </gux-loading-message>
 </div>
@@ -21,33 +23,39 @@
 <h2>Small</h2>
 
 <gux-loading-message style="inline-size: 200px; border: 1px dashed gainsboro">
-  <div slot="primary-message">The content is loading...</div>
-  <div slot="additional-guidance">Thank you for waiting.</div>
+  <div slot="primary-message">Processing your data...</div>
+  <div slot="additional-guidance">
+    This may take a few moments. Please stay on this page.
+  </div>
   <gux-radial-progress
     slot="progress"
-    screenreader-text="loading"
+    screenreader-text="Loading is 10% complete"
   ></gux-radial-progress>
 </gux-loading-message>
 
 <h2>Medium</h2>
 
 <gux-loading-message style="inline-size: 400px; border: 1px dashed gainsboro">
-  <div slot="primary-message">The content is loading...</div>
-  <div slot="additional-guidance">Thank you for waiting.</div>
+  <div slot="primary-message">Processing your data...</div>
+  <div slot="additional-guidance">
+    This may take a few moments. Please stay on this page.
+  </div>
   <gux-radial-progress
     slot="progress"
-    screenreader-text="loading"
+    screenreader-text="Loading is 10% complete"
   ></gux-radial-progress>
 </gux-loading-message>
 
 <h2>Large</h2>
 
 <gux-loading-message style="inline-size: 600px; border: 1px dashed gainsboro">
-  <div slot="primary-message">The content is loading...</div>
-  <div slot="additional-guidance">Thank you for waiting.</div>
+  <div slot="primary-message">Processing your data...</div>
+  <div slot="additional-guidance">
+    This may take a few moments. Please stay on this page.
+  </div>
   <gux-radial-progress
     slot="progress"
-    screenreader-text="loading"
+    screenreader-text="Loading is 10% complete"
   ></gux-radial-progress>
 </gux-loading-message>
 
@@ -59,13 +67,13 @@
     setInterval(() => {
         const html = window.toHTML(`
         <gux-loading-message>
-          <div slot="primary-message">The content is loading...</div>
-          <div slot="additional-guidance">Thank you for waiting.</div>
+          <div slot="primary-message">Processing your data...</div>
+          <div slot="additional-guidance">This may take a few moments. Please stay on this page.</div>
           <gux-radial-progress
             slot="progress"
             value="1"
             max="10"
-            screenreader-text="loading"
+            screenreader-text="Loading is 10% complete"
           ></gux-radial-progress>
         </gux-loading-message>
         `);


### PR DESCRIPTION
I think in this instance it could be seen that the `screereader-text` property should be optional on the gux-radial-progress as the surrounding context could sufficiently describe the radial progress but I think this would not be the right step forward imo as this is just a singular case where the radial loading is used within the gux-loading-message for example. The user still can alter the component to their liking so thats the route I took in this PR.

[✅ Closes: COMUI-4146](https://inindca.atlassian.net/browse/COMUI-4146)