### PR TITLE
fix(screen-reader-beta): remove component from contributing to layout

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-screen-reader/gux-screen-reader.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-screen-reader/gux-screen-reader.scss
@@ -1,7 +1,7 @@
 @use '~genesys-spark/dist/scss/mixins.scss';
 
 :host {
-  position: relative;
+  display: contents;
 }
 
 .gux-sr-only {


### PR DESCRIPTION
**Issue**
The issue is that is you are to use the `gux-screen-reader` component in a div with a flex layout and if you have a `gap` property for example the `gux-screen-reader` will take up space in the layout which is undesirable.

**Note**
This is supported by all browsers AFAIK. There is some posts online about accessibility but I think in our case its fine as we are just rendering a `span` element and its not much more complex than that.

The `display:contents` basically just removes the element(gux-screen-reader) from the layout flow but keeps the children in the DOM which in this case would be the span element.

Please test this out in nvda,jaws etc.

Here is some markup to reproduce the layout issue 👍 


```
<div class="flex">
  <span>This is a test</span>
  <gux-screen-reader-beta>this is not</gux-screen-reader-beta>
  <span>This is a test aswell</span>
</div>

<style>
  .flex {
    display: flex;
    gap: 10px;
    flex-direction: row;
  }
</style>
```

✅ Closes: COMUI-4174