### PR TITLE
fix(gux-dropdown): Use all slotted option content not just first node

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown-multi/gux-dropdown-multi.tsx
@@ -25,7 +25,7 @@ import translationResources from './i18n/en.json';
 import {
   getSearchOption,
   setInitialActiveOption,
-  getOptionDefaultSlot,
+  getOptionDefaultSlotText,
   convertValueToArray
 } from '../gux-listbox/gux-listbox.service';
 import { GuxFilterTypes } from '../gux-dropdown/gux-dropdown.types';
@@ -478,8 +478,7 @@ export class GuxDropdownMulti {
     if (textInputLength > 0 && !this.loading) {
       const option = getSearchOption(this.listboxElement, textInput);
       if (option && this.filterType !== 'custom') {
-        const optionSlotTextContent =
-          getOptionDefaultSlot(option)?.textContent.trim();
+        const optionSlotTextContent = getOptionDefaultSlotText(option);
         return optionSlotTextContent?.substring(textInputLength);
       }
 
@@ -512,7 +511,7 @@ export class GuxDropdownMulti {
   private getSelectedOptionValueString(): string {
     return this.getOptionElementByValue(this.value)
       .map(option => {
-        return getOptionDefaultSlot(option)?.textContent.trim();
+        return getOptionDefaultSlotText(option);
       })
       .join(', ');
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -27,7 +27,7 @@ import {
   getSearchOption,
   getListOptions,
   setInitialActiveOption,
-  getOptionDefaultSlot
+  getOptionDefaultSlotText
 } from '../gux-listbox/gux-listbox.service';
 import {
   ListboxOptionElement,
@@ -399,9 +399,7 @@ export class GuxDropdown {
     if (filterLength > 0 && !this.loading) {
       const option = getSearchOption(this.listboxElement, filter);
       if (option && this.filterType !== 'custom') {
-        //The text content needs to be trimmed as white space can occur around the textContent if options are populated asynchronously.
-        const optionSlotTextContent =
-          getOptionDefaultSlot(option)?.textContent.trim();
+        const optionSlotTextContent = getOptionDefaultSlotText(option);
         return optionSlotTextContent?.substring(filterLength);
       }
     }
@@ -452,7 +450,7 @@ export class GuxDropdown {
   }
 
   private getOptionDefaultText(optionElement: HTMLGuxOptionElement) {
-    return getOptionDefaultSlot(optionElement)?.textContent.trim();
+    return getOptionDefaultSlotText(optionElement);
   }
 
   private renderOption(option: HTMLGuxOptionElement): JSX.Element {

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/__snapshots__/gux-dropdown.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/__snapshots__/gux-dropdown.spec.ts.snap
@@ -142,6 +142,78 @@ exports[`gux-dropdown #render should render as expected with gux-option 1`] = `
 </gux-dropdown>
 `;
 
+exports[`gux-dropdown #render should render as expected with gux-option whose slotted content includes whitespace 1`] = `
+<gux-dropdown lang="en" value="f">
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <gux-popup>
+      <div class="gux-target-container-not-filterable" slot="target">
+        <button type="button" class="gux-field gux-field-button" aria-haspopup="listbox" aria-expanded="false">
+          <div class="gux-field-content">
+            <div class="gux-selected-option">
+              <gux-truncate dir="auto">
+                Frog
+              </gux-truncate>
+            </div>
+          </div>
+          <gux-icon class="gux-expand-icon" screenreader-text="Dropdown" size="small" iconname="custom/chevron-down-small-regular">
+          </gux-icon>
+        </button>
+      </div>
+      <slot slot="popup">
+      </slot>
+    </gux-popup>
+  </template>
+  <gux-listbox aria-label="Animals" role="listbox" tabindex="0">
+    <template shadowrootmode="open">
+      <slot>
+      </slot>
+    </template>
+    <gux-option value="e" id="gux-option-i" role="option" aria-selected="false" aria-disabled="false">
+      <template shadowrootmode="open">
+        <div class="gux-option-wrapper">
+          <gux-truncate tooltip-placement="right">
+            <slot>
+            </slot>
+          </gux-truncate>
+          <slot name="subtext">
+          </slot>
+        </div>
+      </template>Eel
+    </gux-option>
+    <gux-option value="f" id="gux-option-i" role="option" class="gux-selected gux-show-subtext" aria-selected="true" aria-disabled="false">
+      <template shadowrootmode="open">
+        <div class="gux-option-wrapper">
+          <gux-truncate tooltip-placement="right">
+            <slot>
+            </slot>
+          </gux-truncate>
+          <slot name="subtext">
+          </slot>
+        </div>
+      </template>
+      <span>
+        Frog
+      </span>
+      <span slot="subtext">
+        Amphibian
+      </span>
+    </gux-option>
+    <gux-option value="g" id="gux-option-i" role="option" aria-selected="false" aria-disabled="false">
+      <template shadowrootmode="open">
+        <div class="gux-option-wrapper">
+          <gux-truncate tooltip-placement="right">
+            <slot>
+            </slot>
+          </gux-truncate>
+          <slot name="subtext">
+          </slot>
+        </div>
+      </template>Goat
+    </gux-option>
+  </gux-listbox>
+</gux-dropdown>
+`;
+
 exports[`gux-dropdown #render should render as expected with gux-option-group and gux-option 1`] = `
 <gux-dropdown lang="en" value="f">
   <template shadowrootmode="open" shadowrootdelegatesfocus>

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.common.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.common.ts
@@ -9,7 +9,9 @@ const listboxContent = {
     <gux-option value="a">Ant</gux-option>
     <gux-option value="b">Bear Large<span slot="subtext">Large</span></gux-option>
     <gux-option value="be">Bee Small<span slot="subtext">Small</span></gux-option>
-    <gux-option value="c">Cat</gux-option>
+    <gux-option value="c">
+      <span>Cat</span>
+    </gux-option>
     <gux-option value="">None</gux-option>
   `,
   'gux-option-icon': `

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.e2e.playwright.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.e2e.playwright.ts
@@ -87,6 +87,15 @@ test.describe('gux-dropdown', () => {
       visibleItems = await getUnfilteredOptions(page, 'gux-option');
       await expect(visibleItems).toHaveCount(2);
       await expect(visibleItems.first()).toContainText('Bear');
+
+      await filterInput.selectText();
+      await page.keyboard.press('c');
+      await page.waitForChanges();
+
+      // Should find the "Cat" option even though its slotted content starts with whitespace
+      visibleItems = await getUnfilteredOptions(page, 'gux-option');
+      await expect(visibleItems).toHaveCount(1);
+      await expect(visibleItems.first()).toContainText('Cat');
     });
 
     test('does not filter items when filter type is custom', async ({

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/tests/gux-dropdown.spec.ts
@@ -142,5 +142,28 @@ describe('gux-dropdown', () => {
       expect(page.rootInstance).toBeInstanceOf(GuxDropdown);
       expect(page.root).toMatchSnapshot();
     });
+    it(`should render as expected with gux-option whose slotted content includes whitespace`, async () => {
+      const components = [GuxDropdown, GuxListbox, GuxOption];
+      // With frog option selected below, the snapshot should show the selected item's text with
+      // dropdown closed as "Frog"
+      // Prior bug only considered first node of slot content, which below is a whitespace text node.
+      // And not "Frog Amphibian" because subtext slot should be ignored.
+      const html = `
+      <gux-dropdown lang="en" value="f">
+        <gux-listbox aria-label="Animals">
+          <gux-option value="e">Eel</gux-option>
+          <gux-option value="f">
+            <span>Frog</span>
+            <span slot="subtext">Amphibian</span>
+          </gux-option>
+          <gux-option value="g">Goat</gux-option>
+        </gux-listbox>
+      </gux-dropdown>
+      `;
+      const page = await newSpecPage({ components, html, language });
+
+      expect(page.rootInstance).toBeInstanceOf(GuxDropdown);
+      expect(page.root).toMatchSnapshot();
+    });
   });
 });

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/gux-listbox-multi.tsx
@@ -26,7 +26,7 @@ import {
   setNextOptionActive,
   setPreviousOptionActive,
   hasActiveOption,
-  getOptionDefaultSlot,
+  getOptionDefaultSlotText,
   convertValueToArray
 } from '../gux-listbox/gux-listbox.service';
 
@@ -275,8 +275,7 @@ export class GuxListboxMulti {
       );
 
       if (this.filterType !== 'custom' && this.filterType !== 'none') {
-        listboxOption.filtered = !getOptionDefaultSlot(listboxOption)
-          ?.textContent.trim()
+        listboxOption.filtered = !getOptionDefaultSlotText(listboxOption)
           .toLowerCase()
           .startsWith(this.textInput.toLowerCase());
       }

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/gux-listbox.service.ts
@@ -1,4 +1,5 @@
 import { ListboxOptionElement } from './options/option-types';
+import { getTextContentFromNodes } from '@utils/dom/get-text-content-from-nodes';
 
 export function getListOptions(
   list: HTMLGuxListboxElement
@@ -216,17 +217,18 @@ export function matchOption(
   option: ListboxOptionElement,
   matchString: string
 ): boolean {
-  //The text content needs to be trimmed as white space can occur around the textContent if options are populated asynchronously.
-  return getOptionDefaultSlot(option)
-    ?.textContent.trim()
+  return getOptionDefaultSlotText(option)
     .toLowerCase()
     .startsWith(matchString.toLowerCase());
 }
 
-export function getOptionDefaultSlot(
-  option: ListboxOptionElement
-): Node | undefined {
-  return option.shadowRoot.querySelector('slot')?.assignedNodes()[0];
+/**
+ * Get the content of a list option's default slot as text
+ */
+export function getOptionDefaultSlotText(option: ListboxOptionElement): string {
+  const slottedContent =
+    option.shadowRoot.querySelector('slot')?.assignedNodes() ?? [];
+  return getTextContentFromNodes(slottedContent);
 }
 
 export function convertValueToArray(value: string): string[] {

--- a/packages/genesys-spark-components/src/utils/dom/get-text-content-from-nodes.ts
+++ b/packages/genesys-spark-components/src/utils/dom/get-text-content-from-nodes.ts
@@ -1,13 +1,17 @@
 export function getTextContentFromNodes(elements: Node[]): string {
-  return elements
-    .reduce((acc, cv) => {
-      if (cv.nodeName === 'SLOT') {
-        const slotElements = (cv as HTMLSlotElement).assignedNodes();
-        return acc.concat(getTextContentFromNodes(slotElements));
-      }
+  return (
+    elements
+      .reduce((acc, cv) => {
+        if (cv.nodeName === 'SLOT') {
+          const slotElements = (cv as HTMLSlotElement).assignedNodes();
+          return acc.concat(getTextContentFromNodes(slotElements));
+        }
 
-      return acc.concat(cv.textContent);
-    }, [] as string[])
-    .map(s => s.trim())
-    .join(' ');
+        return acc.concat(cv.textContent);
+      }, [] as string[])
+      .map(s => s.trim())
+      // Filter out any blanks so the join doesn't add unwanted whitespace
+      .filter(s => !!s)
+      .join(' ')
+  );
 }


### PR DESCRIPTION
Fix an issue where <gux-option> elements whose first slotted node was whitespace would make the selected option text show as blank when that option was selected.

Also addresses an issue where the starts-with filter mode would fail to find the option due to its leading whitespace.

https://inindca.atlassian.net/browse/COMUI-4223