### PR TITLE
docs(skip-navigation-list): Add note and fix typo on stepper

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-stepper/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-stepper/example.html
@@ -31,7 +31,7 @@
     <gux-step-title slot="title">Payment Method</gux-step-title>
   </gux-step>
   <gux-step step-id="preview" status="incomplete">
-    <gux-step-title slot="title">Preivew</gux-step-title>
+    <gux-step-title slot="title">Preview</gux-step-title>
   </gux-step>
   <gux-step step-id="finalise-order" status="incomplete">
     <gux-step-title slot="title">Finalise Order</gux-step-title>

--- a/packages/genesys-spark-components/src/components/stable/gux-skip-navigation-list/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-skip-navigation-list/example.html
@@ -13,3 +13,7 @@
     <a href="#" onclick="notify(event)">Link 4</a>
   </gux-skip-navigation-item>
 </gux-skip-navigation-list>
+
+<p>
+  <strong>Note:</strong> Press the tab key to focus the skip navigation list.
+</p>


### PR DESCRIPTION
I got a note on these examples that there was a typo and the way to access the skip list wasn't clear so just adding a note there. 